### PR TITLE
feat(config_tpl): Create a config template and use it everywhere with `config_templates`, apply the same config to every series with `all_series_config` and add `color_list` to define your color list in one shot

### DIFF
--- a/.devcontainer/ui-lovelace.yaml
+++ b/.devcontainer/ui-lovelace.yaml
@@ -1,3 +1,19 @@
+apexcharts_card_templates:
+  test2:
+    color_list:
+      - red
+      - red
+  test:
+    config_templates: test2
+    graph_span: 24h
+    color_list:
+      - black
+    all_series_config:
+      group_by:
+        duration: 1h
+        func: avg
+      stroke_width: 2
+
 views:
   - title: Main
     panel: true
@@ -586,3 +602,10 @@ views:
                     color: green
                   - value: 25
                     color: orange
+
+          - type: custom:apexcharts-card
+            config_templates:
+              - test
+            series:
+              - entity: sensor.temperature
+              - entity: sensor.temperature

--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -253,119 +253,119 @@ class ChartsCard extends LitElement {
     if (configDup.config_templates && configDup.config_templates.length > 0) {
       configDup = mergeConfigTemplates(getLovelace(), configDup);
     }
-    const { ChartCardExternalConfig } = createCheckers(exportedTypeSuite);
-    if (!configDup.experimental?.disable_config_validation) {
-      try {
+    try {
+      const { ChartCardExternalConfig } = createCheckers(exportedTypeSuite);
+      if (!configDup.experimental?.disable_config_validation) {
         ChartCardExternalConfig.strictCheck(configDup);
-      } catch (e) {
-        throw new Error(`/// apexcharts-card version ${pjson.version} /// ${e.message}`);
       }
-    }
-    if (configDup.all_series_config) {
-      configDup.series.forEach((serie) => {
-        mergeDeepConfig(serie, configDup.all_series_config);
-      });
-    }
-    if (configDup.update_interval) {
-      this._interval = validateInterval(configDup.update_interval, 'update_interval');
-    }
-    if (configDup.graph_span) {
-      this._graphSpan = validateInterval(configDup.graph_span, 'graph_span');
-    }
-    if (configDup.span?.offset) {
-      this._offset = validateOffset(configDup.span.offset, 'span.offset');
-    }
-    if (configDup.span?.end && configDup.span?.start) {
-      throw new Error(`span: Only one of 'start' or 'end' is allowed.`);
-    }
-    configDup.series.forEach((serie, index) => {
-      if (serie.offset) {
-        this._seriesOffset[index] = validateOffset(serie.offset, `series[${index}].offset`);
+      if (configDup.all_series_config) {
+        configDup.series.forEach((serie, index) => {
+          const allDup = JSON.parse(JSON.stringify(configDup.all_series_config));
+          configDup.series[index] = mergeDeepConfig(allDup, serie);
+        });
       }
-    });
-    if (configDup.update_delay) {
-      this._updateDelay = validateInterval(configDup.update_delay, `update_delay`);
-    }
-
-    this._config = mergeDeep(
-      {
-        graph_span: DEFAULT_GRAPH_SPAN,
-        cache: true,
-        useCompress: false,
-        show: { loading: true },
-      },
-      configDup,
-    );
-
-    const defColors = this._config?.color_list || DEFAULT_COLORS;
-    if (this._config) {
-      this._graphs = this._config.series.map((serie, index) => {
-        if (!this._headerColors[index]) {
-          this._headerColors[index] = defColors[index % defColors.length];
-        }
-        if (serie.color) {
-          this._headerColors[index] = serie.color;
-        }
-        serie.fill_raw = serie.fill_raw || DEFAULT_FILL_RAW;
-        serie.extend_to_end = serie.extend_to_end !== undefined ? serie.extend_to_end : true;
-        serie.type = this._config?.chart_type ? undefined : serie.type || DEFAULT_SERIE_TYPE;
-        serie.unit = this._config?.chart_type === 'radialBar' ? '%' : serie.unit;
-        if (!serie.group_by) {
-          serie.group_by = { duration: DEFAULT_DURATION, func: DEFAULT_FUNC, fill: DEFAULT_GROUP_BY_FILL };
-        } else {
-          serie.group_by.duration = serie.group_by.duration || DEFAULT_DURATION;
-          serie.group_by.func = serie.group_by.func || DEFAULT_FUNC;
-          serie.group_by.fill = serie.group_by.fill || DEFAULT_GROUP_BY_FILL;
-        }
-        if (!serie.show) {
-          serie.show = {
-            legend_value: DEFAULT_SHOW_LEGEND_VALUE,
-            in_header: DEFAULT_SHOW_IN_HEADER,
-            in_chart: DEFAULT_SHOW_IN_CHART,
-          };
-        } else {
-          serie.show.legend_value =
-            serie.show.legend_value === undefined ? DEFAULT_SHOW_LEGEND_VALUE : serie.show.legend_value;
-          serie.show.in_chart = serie.show.in_chart === undefined ? DEFAULT_SHOW_IN_CHART : serie.show.in_chart;
-          serie.show.in_header = serie.show.in_header === undefined ? DEFAULT_SHOW_IN_HEADER : serie.show.in_header;
-        }
-        validateInterval(serie.group_by.duration, `series[${index}].group_by.duration`);
-        if (serie.color_threshold && serie.color_threshold.length > 0) {
-          const sorted: ChartCardColorThreshold[] = JSON.parse(JSON.stringify(serie.color_threshold));
-          sorted.sort((a, b) => (a.value < b.value ? -1 : 1));
-          serie.color_threshold = sorted;
-        }
-
-        if (serie.entity) {
-          const editMode = getLovelace()?.editMode;
-          // disable caching for editor
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const caching = editMode === true ? false : this._config!.cache;
-          const graphEntry = new GraphEntry(
-            index,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this._graphSpan!,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            caching,
-            serie,
-            this._config?.span,
-          );
-          if (this._hass) graphEntry.hass = this._hass;
-          return graphEntry;
-        }
-        return undefined;
-      });
-      this._config.series_in_graph = [];
-      this._config.series.forEach((serie, index) => {
-        if (serie.show.in_chart) {
-          this._colors.push(this._headerColors[index]);
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          this._config!.series_in_graph.push(serie);
+      if (configDup.update_interval) {
+        this._interval = validateInterval(configDup.update_interval, 'update_interval');
+      }
+      if (configDup.graph_span) {
+        this._graphSpan = validateInterval(configDup.graph_span, 'graph_span');
+      }
+      if (configDup.span?.offset) {
+        this._offset = validateOffset(configDup.span.offset, 'span.offset');
+      }
+      if (configDup.span?.end && configDup.span?.start) {
+        throw new Error(`span: Only one of 'start' or 'end' is allowed.`);
+      }
+      configDup.series.forEach((serie, index) => {
+        if (serie.offset) {
+          this._seriesOffset[index] = validateOffset(serie.offset, `series[${index}].offset`);
         }
       });
-      this._headerColors = this._headerColors.slice(0, this._config?.series.length);
-    }
+      if (configDup.update_delay) {
+        this._updateDelay = validateInterval(configDup.update_delay, `update_delay`);
+      }
 
+      this._config = mergeDeep(
+        {
+          graph_span: DEFAULT_GRAPH_SPAN,
+          cache: true,
+          useCompress: false,
+          show: { loading: true },
+        },
+        configDup,
+      );
+
+      const defColors = this._config?.color_list || DEFAULT_COLORS;
+      if (this._config) {
+        this._graphs = this._config.series.map((serie, index) => {
+          if (!this._headerColors[index]) {
+            this._headerColors[index] = defColors[index % defColors.length];
+          }
+          if (serie.color) {
+            this._headerColors[index] = serie.color;
+          }
+          serie.fill_raw = serie.fill_raw || DEFAULT_FILL_RAW;
+          serie.extend_to_end = serie.extend_to_end !== undefined ? serie.extend_to_end : true;
+          serie.type = this._config?.chart_type ? undefined : serie.type || DEFAULT_SERIE_TYPE;
+          serie.unit = this._config?.chart_type === 'radialBar' ? '%' : serie.unit;
+          if (!serie.group_by) {
+            serie.group_by = { duration: DEFAULT_DURATION, func: DEFAULT_FUNC, fill: DEFAULT_GROUP_BY_FILL };
+          } else {
+            serie.group_by.duration = serie.group_by.duration || DEFAULT_DURATION;
+            serie.group_by.func = serie.group_by.func || DEFAULT_FUNC;
+            serie.group_by.fill = serie.group_by.fill || DEFAULT_GROUP_BY_FILL;
+          }
+          if (!serie.show) {
+            serie.show = {
+              legend_value: DEFAULT_SHOW_LEGEND_VALUE,
+              in_header: DEFAULT_SHOW_IN_HEADER,
+              in_chart: DEFAULT_SHOW_IN_CHART,
+            };
+          } else {
+            serie.show.legend_value =
+              serie.show.legend_value === undefined ? DEFAULT_SHOW_LEGEND_VALUE : serie.show.legend_value;
+            serie.show.in_chart = serie.show.in_chart === undefined ? DEFAULT_SHOW_IN_CHART : serie.show.in_chart;
+            serie.show.in_header = serie.show.in_header === undefined ? DEFAULT_SHOW_IN_HEADER : serie.show.in_header;
+          }
+          validateInterval(serie.group_by.duration, `series[${index}].group_by.duration`);
+          if (serie.color_threshold && serie.color_threshold.length > 0) {
+            const sorted: ChartCardColorThreshold[] = JSON.parse(JSON.stringify(serie.color_threshold));
+            sorted.sort((a, b) => (a.value < b.value ? -1 : 1));
+            serie.color_threshold = sorted;
+          }
+
+          if (serie.entity) {
+            const editMode = getLovelace()?.editMode;
+            // disable caching for editor
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const caching = editMode === true ? false : this._config!.cache;
+            const graphEntry = new GraphEntry(
+              index,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              this._graphSpan!,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              caching,
+              serie,
+              this._config?.span,
+            );
+            if (this._hass) graphEntry.hass = this._hass;
+            return graphEntry;
+          }
+          return undefined;
+        });
+        this._config.series_in_graph = [];
+        this._config.series.forEach((serie, index) => {
+          if (serie.show.in_chart) {
+            this._colors.push(this._headerColors[index]);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this._config!.series_in_graph.push(serie);
+          }
+        });
+        this._headerColors = this._headerColors.slice(0, this._config?.series.length);
+      }
+    } catch (e) {
+      throw new Error(`/// apexcharts-card version ${pjson.version} /// ${e.message}`);
+    }
     // Full reset only happens in editor mode
     this._reset();
   }

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -6,6 +6,8 @@ import * as t from "ts-interface-checker";
 
 export const ChartCardExternalConfig = t.iface([], {
   "type": t.lit('custom:apexcharts-card'),
+  "config_templates": t.opt(t.array("string")),
+  "color_list": t.opt(t.array("string")),
   "experimental": t.opt(t.iface([], {
     "color_threshold": t.opt("boolean"),
     "disable_config_validation": t.opt("boolean"),
@@ -14,6 +16,7 @@ export const ChartCardExternalConfig = t.iface([], {
   "chart_type": t.opt(t.union(t.lit('line'), t.lit('scatter'), t.lit('pie'), t.lit('donut'), t.lit('radialBar'))),
   "update_interval": t.opt("string"),
   "update_delay": t.opt("string"),
+  "all_series_config": t.opt("ChartCardAllSeriesExternalConfig"),
   "series": t.array("ChartCardSeriesExternalConfig"),
   "graph_span": t.opt("string"),
   "hours_12": t.opt("boolean"),
@@ -39,6 +42,40 @@ export const ChartCardSpanExtConfig = t.iface([], {
   "start": t.opt(t.union(t.lit('minute'), t.lit('hour'), t.lit('day'), t.lit('week'), t.lit('month'), t.lit('year'))),
   "end": t.opt(t.union(t.lit('minute'), t.lit('hour'), t.lit('day'), t.lit('week'), t.lit('month'), t.lit('year'))),
   "offset": t.opt("string"),
+});
+
+export const ChartCardAllSeriesExternalConfig = t.iface([], {
+  "attribute": t.opt("string"),
+  "name": t.opt("string"),
+  "type": t.opt(t.union(t.lit('line'), t.lit('column'), t.lit('area'))),
+  "color": t.opt("string"),
+  "opacity": t.opt("number"),
+  "curve": t.opt(t.union(t.lit('smooth'), t.lit('straight'), t.lit('stepline'))),
+  "stroke_width": t.opt("number"),
+  "extend_to_end": t.opt("boolean"),
+  "unit": t.opt("string"),
+  "invert": t.opt("boolean"),
+  "data_generator": t.opt("string"),
+  "float_precision": t.opt("number"),
+  "min": t.opt("number"),
+  "max": t.opt("number"),
+  "offset": t.opt("string"),
+  "fill_raw": t.opt("GroupByFill"),
+  "show": t.opt(t.iface([], {
+    "as_duration": t.opt("ChartCardPrettyTime"),
+    "legend_value": t.opt("boolean"),
+    "in_header": t.opt("boolean"),
+    "in_chart": t.opt("boolean"),
+    "datalabels": t.opt("boolean"),
+    "hidden_by_default": t.opt("boolean"),
+  })),
+  "group_by": t.opt(t.iface([], {
+    "duration": t.opt("string"),
+    "func": t.opt("GroupByFunc"),
+    "fill": t.opt("GroupByFill"),
+  })),
+  "transform": t.opt("string"),
+  "color_threshold": t.opt(t.array("ChartCardColorThreshold")),
 });
 
 export const ChartCardSeriesExternalConfig = t.iface([], {
@@ -99,6 +136,7 @@ export const ChartCardColorThreshold = t.iface([], {
 const exportedTypeSuite: t.ITypeSuite = {
   ChartCardExternalConfig,
   ChartCardSpanExtConfig,
+  ChartCardAllSeriesExternalConfig,
   ChartCardSeriesExternalConfig,
   ChartCardPrettyTime,
   GroupByFill,

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -1,5 +1,7 @@
 export interface ChartCardExternalConfig {
   type: 'custom:apexcharts-card';
+  config_templates?: string[];
+  color_list?: string[];
   experimental?: {
     color_threshold?: boolean;
     disable_config_validation?: boolean;
@@ -8,6 +10,7 @@ export interface ChartCardExternalConfig {
   chart_type?: 'line' | 'scatter' | 'pie' | 'donut' | 'radialBar';
   update_interval?: string;
   update_delay?: string;
+  all_series_config?: ChartCardAllSeriesExternalConfig;
   series: ChartCardSeriesExternalConfig[];
   graph_span?: string;
   hours_12?: boolean;
@@ -37,6 +40,45 @@ export interface ChartCardSpanExtConfig {
   end?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
   offset?: string;
 }
+
+export interface ChartCardAllSeriesExternalConfig {
+  attribute?: string;
+  name?: string;
+  type?: 'line' | 'column' | 'area';
+  color?: string;
+  opacity?: number;
+  curve?: 'smooth' | 'straight' | 'stepline';
+  stroke_width?: number;
+  extend_to_end?: boolean;
+  unit?: string;
+  invert?: boolean;
+  data_generator?: string;
+  float_precision?: number;
+  min?: number;
+  max?: number;
+  offset?: string;
+  fill_raw?: GroupByFill;
+  show?: {
+    as_duration?: ChartCardPrettyTime;
+    legend_value?: boolean;
+    in_header?: boolean;
+    in_chart?: boolean;
+    datalabels?: boolean;
+    hidden_by_default?: boolean;
+  };
+  group_by?: {
+    duration?: string;
+    func?: GroupByFunc;
+    fill?: GroupByFill;
+  };
+  transform?: string;
+  color_threshold?: ChartCardColorThreshold[];
+}
+
+// Need to duplicate because of https://github.com/gristlabs/ts-interface-checker/issues/35
+// export interface ChartCardSeriesExternalConfig extends ChartCardAllSeriesExternalConfig {
+//   entity: string;
+// }
 export interface ChartCardSeriesExternalConfig {
   entity: string;
   attribute?: string;


### PR DESCRIPTION
This PR adds:
* `config_templates`
* `color_list`
* `all_series_config`

This allows you to:
* Define a template in your main lovelace config and use it in many different places.
* Define a configuration for all the series in a chart instead of having to redefine them each time
* Define a color list instead of defining a color in each entity
* chain config templates

### Configuration Templates

#### General

- Define your config template in the main lovelace configuration and then use it in your cards. This will avoid a lot of repetitions! It's basically YAML anchors, but without using YAML anchors and is very useful if you split your config in multiple files 😄
- You can overload any parameter with a new one
- Arrays will be merged by matching the index
- You can also inherit another template from within a template.
- You can inherit multiple templates at once by making it an array. In this case, the templates will be merged together with the current configuration in the order they are defined. This happens recursively.

  ```yaml
  type: custom:apexcharts-card
  config_templates:
    - template1
    - template2
  # or
  type: custom:apexcharts-card
  config_templates: template1
  ```

The card templates will be applied in the order they are defined: `template2` will be merged with `template1` and then the local config will be merged with the result. You can still chain templates together (ie. define template in a apexcharts-card template. It will follow the path recursively).

Make sure which type of lovelace dashboard you are using before changing the main lovelace configuration:
  * **`managed`** changes are managed by lovelace UI - add the template configuration to configuration in raw editor
      * go to your dashboard
      * click three dots and `Edit dashboard` button
      * click three dots again and click `Raw configuration editor` button
  * **`yaml`** - add template configuration to your dashboard file (`ui-lovelace.yaml` for eg.)

**Note:** Templates have to be defined in all dashboards, they are not shared.

To give you an idea where to put those (in your dashboard file/RAW editor):
```yaml
apexcharts_card_templates:
  default:
    color_list: ['red', 'green', 'blue']

  bandwidth_chart:
    graph_span: 24h
    config_templates: default
    header:
      show: true
      show_states: true
      colorize_states: true
    all_series_config:
      stroke_width: 2
      opacity: 0.3
      type: area

views:
  - title: Main
    panel: true
    cards:
      [...]
```

And then where you define your card, you can consume those templates, and/or overload it:

```yaml
- type: custom:apexcharts-card
  template: bandwidth_chart
  header:
    title: WAN Bandwidth
  series:
    - entity: sensor.wan_download
    - entity: sensor.wan_upload
      invert: true
```

In the end, this would produce the same result as but it's shorter and you can reuse that template elsewhere:
```yaml
- type: custom:apexcharts-card
  graph_span: 24h
  header:
    title: WAN Bandwidth
    show: true
    show_states: true
    colorize_states: true
  all_series_config:
    stroke_width: 2
    opacity: 0.3
    type: area
  color_list: ['red', 'green', 'blue']
  series:
    - entity: sensor.wan_download
    - entity: sensor.wan_upload
      invert: true
```

#### `all_series_config` options

This will allow you to apply some settings to all the series avoiding repetition. It's just syntaxic sugar and doesn't add more features.

Eg:
```yaml
- type: custom:apexcharts-card
  graph_span: 24h
  all_series_config:
    stroke_width: 2
    type: area
    transform: return x / 1024;
    unit: Mb/s
  series:
    - entity: sensor.wan_download
    - entity: sensor.wan_upload
      invert: true
```

Generates the same result as repeating the configuration in each series:
```yaml
- type: custom:apexcharts-card
  graph_span: 24h
  series:
    - entity: sensor.wan_download
      stroke_width: 2
      type: area
      transform: return x / 1024;
      unit: Mb/s
    - entity: sensor.wan_upload
      invert: true
      stroke_width: 2
      type: area
      transform: return x / 1024;
      unit: Mb/s
```