### PR TITLE
feat(apex_config): Support for markers in line charts

### DIFF
--- a/src/apex-layouts.ts
+++ b/src/apex-layouts.ts
@@ -75,9 +75,7 @@ export function getLayoutConfig(config: ChartCardConfig, hass: HomeAssistant | u
         config.chart_type === 'pie' || config.chart_type === 'donut' ? ['var(--card-background-color)'] : undefined,
       width: getStrokeWidth(config, false),
     },
-    markers: {
-      showNullDataPoints: false,
-    },
+    markers: getMarkers(config, false),
     noData: {
       text: 'Loading...',
     },
@@ -159,9 +157,7 @@ export function getBrushLayoutConfig(
         config.chart_type === 'pie' || config.chart_type === 'donut' ? ['var(--card-background-color)'] : undefined,
       width: getStrokeWidth(config, true),
     },
-    markers: {
-      showNullDataPoints: false,
-    },
+    markers: getMarkers(config, true),
     noData: {
       text: 'Loading...',
     },
@@ -413,6 +409,29 @@ function getStrokeWidth(config: ChartCardConfig, brush: boolean) {
     }
     return [undefined, 'line', 'area'].includes(serie.type) ? 5 : 0;
   });
+}
+
+function getMarkers(config: ChartCardConfig, brush: boolean) {
+  if (config.chart_type !== undefined && config.chart_type !== 'line')
+    return {
+      showNullDataPoints: false,
+    };
+
+  let markers = brush ? config?.brush_markers : config?.markers;
+
+  return {
+    size: markers?.size,
+    colors: markers?.colors,
+    strokeColors: markers?.stroke_colors,
+    strokeOpacticy: markers?.stroke_opacity,
+    strokeWidth: markers?.stroke_width,
+    strokeDashArray: markers?.stroke_dash_array,
+    fillOpacity: markers?.fill_opacity,
+    radius: markers?.radius,
+    shape: markers?.shape,
+    showNullDataPoints: markers?.show_null_data_points || false,
+  };
+  return markers;
 }
 
 function getFillType(config: ChartCardConfig, brush: boolean) {

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -38,11 +38,26 @@ export const ChartCardExternalConfig = t.iface([], {
   "apex_config": t.opt("any"),
   "header": t.opt("ChartCardHeaderExternalConfig"),
   "style": t.opt("any"),
+  "markers": t.opt("ChartCardMarkerExtConfig"),
   "card_mod": t.opt("any"),
   "brush": t.opt("ChartCardBrushExtConfig"),
+  "brush_markers": t.opt("ChartCardMarkerExtConfig"),
 });
 
 export const ChartCardChartType = t.union(t.lit('line'), t.lit('scatter'), t.lit('pie'), t.lit('donut'), t.lit('radialBar'));
+
+export const ChartCardMarkerExtConfig = t.iface([], {
+  "size": t.opt(t.union("number", t.array("number"))),
+  "colors": t.opt(t.union("string", t.array("string"))),
+  "stroke_colors": t.opt(t.union("string", t.array("string"))),
+  "stroke_opacity": t.opt(t.union("number", t.array("number"))),
+  "stroke_width": t.opt(t.union("number", t.array("number"))),
+  "stroke_dash_array": t.opt(t.union("number", t.array("number"))),
+  "fill_opacity": t.opt(t.union("number", t.array("number"))),
+  "radius": t.opt("number"),
+  "shape": t.opt(t.union(t.lit('circle'), t.lit('square'))),
+  "show_null_data_points": t.opt("boolean"),
+});
 
 export const ChartCardBrushExtConfig = t.iface([], {
   "selection_span": t.opt("string"),
@@ -128,6 +143,7 @@ export const ChartCardColorThreshold = t.iface([], {
 const exportedTypeSuite: t.ITypeSuite = {
   ChartCardExternalConfig,
   ChartCardChartType,
+  ChartCardMarkerExtConfig,
   ChartCardBrushExtConfig,
   ChartCardSpanExtConfig,
   ChartCardStartEnd,

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -35,12 +35,27 @@ export interface ChartCardExternalConfig {
   // Support to define style (card-mod/card-mod-v3.0 or picture-entity)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   style?: any;
+  markers?: ChartCardMarkerExtConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   card_mod?: any;
   brush?: ChartCardBrushExtConfig;
+  brush_markers?: ChartCardMarkerExtConfig;
 }
 
 export type ChartCardChartType = 'line' | 'scatter' | 'pie' | 'donut' | 'radialBar';
+
+export interface ChartCardMarkerExtConfig {
+  size?: number | number[];
+  colors?: string | string[];
+  stroke_colors?: string | string[];
+  stroke_opacity?: number | number[];
+  stroke_width?: number | number[];
+  stroke_dash_array?: number | number[];
+  fill_opacity?: number | number[];
+  radius?: number;
+  shape?: 'circle' | 'square';
+  show_null_data_points?: boolean;
+}
 
 export interface ChartCardBrushExtConfig {
   selection_span?: string;


### PR DESCRIPTION
Adds support for markers in line charts.  Closes #138.

I haven't quite got my head around how the config gets transformed into what gets fed into ApexCharts, so this may not be the best way to get the data in there - but it works, so hopefully it's at least a useful starting point.  There are a few marker config options which I haven't implemented (offsets and click/hover handlers), as offsets didn't seem particularly useful and I'm not sure whether you have any plans around how click/hover handlers might look (maybe they'd just use the `EVAL:` processing you've just added - thanks again for that!).