### PR TITLE
Fix the tooltip cutting off when extending beyond the card

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -6,7 +6,6 @@ export const styles: CSSResult = css`
   }
 
   ha-card {
-    overflow: hidden;
     position: relative;
   }
 


### PR DESCRIPTION
## Summary
Unhide the overflow so that the tooltip isn't cut off when extending beyond the card.

## Background
I've discovered an issue where the tooltip is cut off. I'm wondering if this is some sort of a freak occasion, as it seems quite a big flaw in the card. 

<img width="373" alt="Screenshot 2021-07-28 at 16 26 32" src="https://user-images.githubusercontent.com/3413870/127335087-6685d298-c298-455c-a5ed-902a2c6ea0e1.png">

I tried debugging it and trying to understand the box model and overflows involved, and found out that the `<ha-card>` element has `overflow: hidden` defined on it. Removing it fixes the issue:
<img width="537" alt="Screenshot 2021-07-28 at 16 46 22" src="https://user-images.githubusercontent.com/3413870/127335147-7737362f-4719-4904-9974-83916c5910e7.png">

I'm sorry if I don't comply with contributing guidelines. I'm not a frequent contributor, so please let me know if I should change something to get it merged.