### PR TITLE
fix: median function fails if it receives an empty table

### DIFF
--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -514,6 +514,7 @@ export default class GraphEntry {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const itemsDup = this._filterNulls([...items]).sort((a, b) => a[1]! - b[1]!);
     if (itemsDup.length === 0) return null;
+    if (itemsDup.length === 1) return itemsDup[0][1];
     const mid = Math.floor((itemsDup.length - 1) / 2);
     if (itemsDup.length % 2 === 1) return itemsDup[mid][1];
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -513,6 +513,7 @@ export default class GraphEntry {
   private _median(items: EntityCachePoints) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const itemsDup = this._filterNulls([...items]).sort((a, b) => a[1]! - b[1]!);
+    if (itemsDup.length === 0) return null;
     const mid = Math.floor((itemsDup.length - 1) / 2);
     if (itemsDup.length % 2 === 1) return itemsDup[mid][1];
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
When `_median` function receive table with nulls only (which results in empty `itemsDup`) then it fails later on `itemsDup[-1][1]` and breaks calculating results for another buckets. 