### PR TITLE
Add state type to long term statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ series:
 
 | Name | Type | Default | Since | Description |
 | ---- | :--: | :-----: | :---: | ----------- |
-| `type` | string | `mean` | NEXT_VERSION | Type of long term statistic to pull. Can be one of `min`, `max`, `mean` or `sum` |
+| `type` | string | `mean` | NEXT_VERSION | Type of long term statistic to pull. Can be one of `min`, `max`, `mean`, `sum` or `state` |
 | `period` | string | `hour` | NEXT_VERSION | Period of statistics to pull. Can be one of `5minute`, `hour`, `day` or `month` |
 | `align` | string | `middle` | NEXT_VERSION | Align the data points to the `start`, `end` or `middle` of the period of the statistics |
 

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -77,7 +77,7 @@ export const ChartCardAllSeriesExternalConfig = t.iface([], {
   "invert": t.opt("boolean"),
   "data_generator": t.opt("string"),
   "statistics": t.opt(t.iface([], {
-    "type": t.opt(t.union(t.lit('mean'), t.lit('max'), t.lit('min'), t.lit('sum'))),
+    "type": t.opt(t.union(t.lit('mean'), t.lit('max'), t.lit('min'), t.lit('sum'), t.lit('state'))),
     "period": t.opt("StatisticsPeriod"),
     "align": t.opt(t.union(t.lit('start'), t.lit('end'), t.lit('middle'))),
   })),

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -77,7 +77,7 @@ export interface ChartCardAllSeriesExternalConfig {
   invert?: boolean;
   data_generator?: string;
   statistics?: {
-    type?: 'mean' | 'max' | 'min' | 'sum';
+    type?: 'mean' | 'max' | 'min' | 'sum' | 'state';
     period?: StatisticsPeriod;
     align?: 'start' | 'end' | 'middle';
   };


### PR DESCRIPTION
Added the statistics type `state`. This could be used to graph the 5-minute, hourly or daily statistics state of an entity, representing for example the daily consumed energy in stead of the running sum since the start of the statistics.