### PR TITLE
Fix for auto yaxis height with stacked graphs

### DIFF
--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -1188,8 +1188,8 @@ class ChartsCard extends LitElement {
           if (max === undefined || max === null) {
             max = elt.max[1];
           } else if (elt.max[1] !== null) {
-            if (this._config.stacked) {
-              max = max + elt.max[1];
+            if (this._config?.stacked) {
+              max += elt.max[1];
             } else if (max < elt.max[1]) {
               max = elt.max[1];
             }

--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -1187,8 +1187,12 @@ class ChartsCard extends LitElement {
           }
           if (max === undefined || max === null) {
             max = elt.max[1];
-          } else if (elt.max[1] !== null && max < elt.max[1]) {
-            max = elt.max[1];
+          } else if (elt.max[1] !== null) {
+            if (this._config.stacked) {
+              max = max + elt.max[1];
+            } else if (max < elt.max[1]) {
+              max = elt.max[1];
+            }
           }
         });
         if (yaxis.align_to !== undefined) {


### PR DESCRIPTION
I noticed that a stacked graph with the yaxis being set to auto will get clamped to the max value in the series, rather then the sum of the values. This change fixed it for me, but I'm new to using the graph, so let me know if this may cause any issues.

Before
![CaptureBefore](https://user-images.githubusercontent.com/277678/165646040-523b7e8e-1a90-4be4-8f26-d842a41ebbaf.JPG)

After
![Capture](https://user-images.githubusercontent.com/277678/165645974-9fc84069-fd47-4604-9916-6389f4b95583.JPG)



