### PR TITLE
fix: start_with_last not working in some cases (#340)

### DIFF
--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -509,10 +509,8 @@ export default class GraphEntry {
       }
       if (this._config.group_by.start_with_last) {
         if (index > 0) {
-          if (bucket.data.length === 0 || bucket.data[0][0] !== bucket.timestamp) {
-            const prevBucketData = buckets[index - 1].data;
-            bucket.data.unshift([bucket.timestamp, prevBucketData[prevBucketData.length - 1][1]]);
-          }
+          const prevBucketData = buckets[index - 1].data;
+          bucket.data.unshift([bucket.timestamp, prevBucketData[prevBucketData.length - 1][1]]);
         } else {
           const firstIndexAfter = history.data.findIndex((entry) => {
             if (entry[0] > bucket.timestamp) return true;


### PR DESCRIPTION
As agreed in #340, start_with_last should be able to prepend the previous bucket's last value regardless of the current bucket's first data point timestamp.