### PR TITLE
Better text color selection for a given background

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,7 +112,7 @@ export function computeColor(color: string): string {
 
 export function computeTextColor(backgroundColor: string): string {
   const colorObj = new TinyColor(backgroundColor);
-  if (colorObj.isValid && colorObj.getLuminance() > 0.5) {
+  if (colorObj.isValid && colorObj.isLight()) {
     return '#000'; // bright colors - black font
   } else {
     return '#fff'; // dark colors - white font


### PR DESCRIPTION
Currently, apexcharts selects text color inadequately. It can select white text for quiet bright background.
The problem is that `computeTextColor()` function uses linear `colorObj.getLuminance()`, which is not how human percepts color.
TinyColor has `isLight()`/`isDark()` methods, which work in gamma space, and my experiments indicate it works better for this purpose.
Here is the comparison (before/after):
![apex-charts-bg-color-BAACC7-is-unreadable-big](https://github.com/user-attachments/assets/7a40748c-11f5-4720-adb0-cc02ac280d7f)
![apex-charts-bg-color-BAACC7-is-unreadable-big-fixed](https://github.com/user-attachments/assets/6643ddad-4ae5-4e0e-970f-ccaff173dd77)

The color of the graph is `#BAACC7` which has linear luminance of about 0.44. This is less than 0.5, thus master version of apex-charts selects white text color. However, as you can probably see, black text color is much more readable.
