### PR TITLE
fix(series): `float_precision` will enforce the number of digits of the fraction

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,7 +112,7 @@ export function computeColor(color: string): string {
 
 export function computeTextColor(backgroundColor: string): string {
   const colorObj = new TinyColor(backgroundColor);
-  if (colorObj.isValid && colorObj.getLuminance() > 0.5) {
+  if (colorObj.isValid && colorObj.isLight()) {
     return '#000'; // bright colors - black font
   } else {
     return '#fff'; // dark colors - white font

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,7 +112,7 @@ export function computeColor(color: string): string {
 
 export function computeTextColor(backgroundColor: string): string {
   const colorObj = new TinyColor(backgroundColor);
-  if (colorObj.isValid && colorObj.isLight()) {
+  if (colorObj.isValid && colorObj.getLuminance() > 0.5) {
     return '#000'; // bright colors - black font
   } else {
     return '#fff'; // dark colors - white font
@@ -312,20 +312,27 @@ export function truncateFloat(
 export function myFormatNumber(
   num: string | number | null | undefined,
   localeOptions?: FrontendLocaleData,
-  precision?: number | undefined,
+  precision?: number,
 ): string | null {
-  let lValue: string | number | null | undefined = num;
-  if (lValue === undefined || lValue === null) return null;
-  if (typeof lValue === 'string') {
-    lValue = parseFloat(lValue);
-    if (Number.isNaN(lValue)) {
-      return num as string;
-    }
+  if (num === null || num === undefined) {
+    return null;
   }
-  return formatNumber(lValue, localeOptions, {
-    maximumFractionDigits: precision === undefined ? DEFAULT_FLOAT_PRECISION : precision,
-  });
+
+  let value: number;
+  if (typeof num === 'string') {
+    value = parseFloat(num);
+    if (Number.isNaN(value)) {
+      return num;
+    }
+  } else {
+    value = num;
+  }
+  const effectivePrecision = precision ?? DEFAULT_FLOAT_PRECISION;
+  const fixedPrecisionValue = value.toFixed(effectivePrecision);
+  return formatNumber(fixedPrecisionValue, localeOptions);
 }
+
+
 
 export function computeTimezoneDiffWithLocal(timezone: string | undefined): number {
   if (!timezone) return 0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -312,27 +312,21 @@ export function truncateFloat(
 export function myFormatNumber(
   num: string | number | null | undefined,
   localeOptions?: FrontendLocaleData,
-  precision?: number,
+  precision?: number | undefined,
 ): string | null {
-  if (num === null || num === undefined) {
-    return null;
-  }
-
-  let value: number;
-  if (typeof num === 'string') {
-    value = parseFloat(num);
-    if (Number.isNaN(value)) {
-      return num;
+  let lValue: string | number | null | undefined = num;
+  if (lValue === undefined || lValue === null) return null;
+  if (typeof lValue === 'string') {
+    lValue = parseFloat(lValue);
+    if (Number.isNaN(lValue)) {
+      return num as string;
     }
-  } else {
-    value = num;
   }
-  const effectivePrecision = precision ?? DEFAULT_FLOAT_PRECISION;
-  const fixedPrecisionValue = value.toFixed(effectivePrecision);
-  return formatNumber(fixedPrecisionValue, localeOptions);
+  return formatNumber(lValue, localeOptions, {
+    minimumFractionDigits: precision === undefined ? 0 : precision,
+    maximumFractionDigits: precision === undefined ? DEFAULT_FLOAT_PRECISION : precision,
+  });
 }
-
-
 
 export function computeTimezoneDiffWithLocal(timezone: string | undefined): number {
   if (!timezone) return 0;


### PR DESCRIPTION
When using a larger float_precision, it now adds trailing zero's until the float_precision value

<img width="1043" height="614" alt="image" src="https://github.com/user-attachments/assets/da32b7e8-3c2f-45f7-84d7-2a54249ffb67" />

Closes #841 
