### PR TITLE
feat(series): show unit before the value with `unit: before_value`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The card strictly validates all the options available (but not for the `apex_con
 | `extremas` | boolean or string | `false` | v1.7.0 | If `true`, will show the min and the max of the series in the chart.  If the value is `time`, it will display also the time of the min/max value on top of the value. From v2.0.0, `min` or `max` will display the min or the max only and `min+time` or `max+time` will display the time of the min or the max. Displaying the time doesn't work with `stacked: true`. |
 | `in_brush` | boolean | `false` | v1.8.0 | See [brush](#brush-experimental-feature) |
 | `offset_in_name` | boolean | `true` | v1.8.0 | If `true`, it appends the offset information to the name of the series. If `false`, it doesn't |
+| `unit` | boolean or string | `true` | NEXT_VERSION | If `false`, the unit won't be displayed. If set to `before_value`, the unit will be displayed in front of the value. Does nothing when `as_duration` is set to `true` |
 
 ### `header_actions` or `title_actions` options
 

--- a/src/apex-layouts.ts
+++ b/src/apex-layouts.ts
@@ -309,9 +309,9 @@ function getYTooltipFormatter(config: ChartCardConfig, hass: HomeAssistant | und
     );
     let tooltipValue = '';
     if (conf.series_in_graph[opts.seriesIndex]?.show.as_duration) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       tooltipValue = `<strong>${prettyPrintTime(
         lValue,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         conf.series_in_graph[opts.seriesIndex].show.as_duration!,
       )}</strong>`;
     } else if (conf.series_in_graph[opts.seriesIndex]?.show.unit === 'before_value') {

--- a/src/apex-layouts.ts
+++ b/src/apex-layouts.ts
@@ -307,10 +307,21 @@ function getYTooltipFormatter(config: ChartCardConfig, hass: HomeAssistant | und
       undefined,
       hass2?.states[conf.series_in_graph[opts.seriesIndex].entity],
     );
-    return conf.series_in_graph[opts.seriesIndex]?.show.as_duration
-      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        [`<strong>${prettyPrintTime(lValue, conf.series_in_graph[opts.seriesIndex].show.as_duration!)}</strong>`]
-      : [`<strong>${lValue} ${uom}</strong>`];
+    let tooltipValue = '';
+    if (conf.series_in_graph[opts.seriesIndex]?.show.as_duration) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      tooltipValue = `<strong>${prettyPrintTime(
+        lValue,
+        conf.series_in_graph[opts.seriesIndex].show.as_duration!,
+      )}</strong>`;
+    } else if (conf.series_in_graph[opts.seriesIndex]?.show.unit === 'before_value') {
+      tooltipValue = `<strong>${uom} ${lValue}</strong>`;
+    } else if (conf.series_in_graph[opts.seriesIndex]?.show.unit === true) {
+      tooltipValue = `<strong>${lValue} ${uom}</strong>`;
+    } else {
+      tooltipValue = `<strong>${lValue}</strong>`;
+    }
+    return [tooltipValue];
   };
 }
 
@@ -419,7 +430,13 @@ function getLegendFormatter(config: ChartCardConfig, hass: HomeAssistant | undef
             );
       let valueString = '';
       if (value === undefined || value === null) {
-        valueString = `<strong>${NO_VALUE} ${uom}</strong>`;
+        if (conf.series_in_graph[opts.seriesIndex]?.show.unit === 'before_value') {
+          valueString = `<strong>${uom} ${NO_VALUE}</strong>`;
+        } else if (conf.series_in_graph[opts.seriesIndex]?.show.unit === true) {
+          valueString = `<strong>${NO_VALUE} ${uom}</strong>`;
+        } else {
+          valueString = `<strong>${NO_VALUE}</strong>`;
+        }
       } else {
         if (conf.series_in_graph[opts.seriesIndex]?.show.as_duration) {
           valueString = `<strong>${prettyPrintTime(
@@ -428,7 +445,13 @@ function getLegendFormatter(config: ChartCardConfig, hass: HomeAssistant | undef
             conf.series_in_graph[opts.seriesIndex].show.as_duration!,
           )}</strong>`;
         } else {
-          valueString = `<strong>${value} ${uom}</strong>`;
+          if (conf.series_in_graph[opts.seriesIndex]?.show.unit === 'before_value') {
+            valueString = `<strong>${uom} ${value}</strong>`;
+          } else if (conf.series_in_graph[opts.seriesIndex]?.show.unit === true) {
+            valueString = `<strong>${value} ${uom}</strong>`;
+          } else {
+            valueString = `<strong>${value}</strong>`;
+          }
         }
       }
       return [name + ':', valueString];

--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -61,6 +61,7 @@ import {
   DEFAULT_FLOAT_PRECISION,
   DEFAULT_SHOW_IN_CHART,
   DEFAULT_SHOW_IN_HEADER,
+  DEFAULT_SHOW_UNIT,
   DEFAULT_SHOW_IN_LEGEND,
   DEFAULT_SHOW_LEGEND_VALUE,
   DEFAULT_SHOW_NAME_IN_HEADER,
@@ -405,6 +406,7 @@ class ChartsCard extends LitElement {
               in_legend: DEFAULT_SHOW_IN_LEGEND,
               legend_value: DEFAULT_SHOW_LEGEND_VALUE,
               in_header: DEFAULT_SHOW_IN_HEADER,
+              unit: DEFAULT_SHOW_UNIT,
               in_chart: DEFAULT_SHOW_IN_CHART,
               name_in_header: DEFAULT_SHOW_NAME_IN_HEADER,
               null_in_header: DEFAULT_SHOW_NULL_IN_HEADER,
@@ -742,6 +744,9 @@ class ChartsCard extends LitElement {
                 }}"
               >
                 <div id="state__value">
+                  ${serie.show.unit === 'before_value'
+                      ? html`<span id="uom">${computeUom(index, this._config?.series, this._entities)}</span>`
+                      : ''}
                   <span id="state" style="${this._computeHeaderStateColor(serie, this._headerState?.[index])}"
                     >${this._headerState?.[index] === 0
                       ? 0
@@ -749,7 +754,7 @@ class ChartsCard extends LitElement {
                       ? prettyPrintTime(this._headerState?.[index], serie.show.as_duration)
                       : this._computeLastState(this._headerState?.[index], index) || NO_VALUE}</span
                   >
-                  ${!serie.show.as_duration
+                  ${!serie.show.as_duration && (serie.show.unit === undefined || (serie.show.unit !== false && serie.show.unit !== 'before_value'))
                     ? html`<span id="uom">${computeUom(index, this._config?.series, this._entities)}</span>`
                     : ''}
                 </div>

--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -744,9 +744,9 @@ class ChartsCard extends LitElement {
                 }}"
               >
                 <div id="state__value">
-                  ${serie.show.unit === 'before_value'
-                      ? html`<span id="uom">${computeUom(index, this._config?.series, this._entities)}</span>`
-                      : ''}
+                  ${!serie.show.as_duration && serie.show.unit === 'before_value'
+                    ? html`<span id="uom">${computeUom(index, this._config?.series, this._entities)}</span>`
+                    : ''}
                   <span id="state" style="${this._computeHeaderStateColor(serie, this._headerState?.[index])}"
                     >${this._headerState?.[index] === 0
                       ? 0
@@ -754,7 +754,7 @@ class ChartsCard extends LitElement {
                       ? prettyPrintTime(this._headerState?.[index], serie.show.as_duration)
                       : this._computeLastState(this._headerState?.[index], index) || NO_VALUE}</span
                   >
-                  ${!serie.show.as_duration && (serie.show.unit === undefined || (serie.show.unit !== false && serie.show.unit !== 'before_value'))
+                  ${!serie.show.as_duration && serie.show.unit === true
                     ? html`<span id="uom">${computeUom(index, this._config?.series, this._entities)}</span>`
                     : ''}
                 </div>

--- a/src/const.ts
+++ b/src/const.ts
@@ -16,6 +16,7 @@ export const DEFAULT_FILL_RAW = 'null';
 export const DEFAULT_SHOW_IN_LEGEND = true;
 export const DEFAULT_SHOW_LEGEND_VALUE = true;
 export const DEFAULT_SHOW_IN_HEADER = true;
+export const DEFAULT_SHOW_UNIT = true;
 export const DEFAULT_SHOW_IN_CHART = true;
 export const DEFAULT_SHOW_NAME_IN_HEADER = true;
 export const DEFAULT_SHOW_OFFSET_IN_NAME = true;

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -118,6 +118,7 @@ export const ChartCardSeriesShowConfigExt = t.iface([], {
   "in_legend": t.opt("boolean"),
   "legend_value": t.opt("boolean"),
   "in_header": t.opt(t.union("boolean", t.lit('raw'), t.lit('before_now'), t.lit('after_now'))),
+  "unit": t.opt(t.union("boolean", t.lit('before_value'))),
   "name_in_header": t.opt("boolean"),
   "null_in_header": t.opt("boolean"),
   "zero_in_header": t.opt("boolean"),

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -120,6 +120,7 @@ export interface ChartCardSeriesShowConfigExt {
   in_legend?: boolean;
   legend_value?: boolean;
   in_header?: boolean | 'raw' | 'before_now' | 'after_now';
+  unit?: boolean | 'before_value';
   name_in_header?: boolean;
   null_in_header?: boolean;
   zero_in_header?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface ChartCardSeriesConfig extends ChartCardSeriesExternalConfig {
 export interface ChartCardSeriesShowConfig extends ChartCardSeriesShowConfigExt {
   legend_value: boolean;
   in_header: boolean | 'raw' | 'before_now' | 'after_now';
+  unit: boolean | 'before_value';
   name_in_header: boolean;
   null_in_header: boolean;
   zero_in_header: boolean;

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -22,6 +22,22 @@ views:
         columns: 3
         cards:
           - type: custom:apexcharts-card
+            graph_span: 30min
+            header:
+              show: true
+              show_states: true
+
+            series:
+              - entity: sensor.random0_100
+                unit: '%'
+                show:
+                  as_duration: second
+                  unit: before_value
+              - entity: sensor.random_0_1000
+                unit: '%'
+                show:
+                  unit: before_value
+          - type: custom:apexcharts-card
             apex_config:
               chart:
                 toolbar:


### PR DESCRIPTION
additional config element in 'show' for series, options: true/false/before_value, default: true

<img width="1055" height="732" alt="image" src="https://github.com/user-attachments/assets/bcbc6f83-a17f-4c59-94cc-7f434e1d28e0" />
