### PR TITLE
Fix extremas incorrectly placed when stacked

### DIFF
--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -1113,6 +1113,7 @@ class ChartsCard extends LitElement {
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const points: any = [];
+    const stacked = this._config?.stacked;
     const multiYAxis =
       this._config?.apex_config?.yaxis &&
       Array.isArray(this._config.apex_config.yaxis) &&
@@ -1120,7 +1121,7 @@ class ChartsCard extends LitElement {
     points.push({
       x: offset ? value[0] - offset : value[0],
       y: invert && value[1] ? -value[1] : value[1],
-      seriesIndex: index,
+      ...(stacked ? {} : { seriesIndex: index }),
       yAxisIndex: multiYAxis ? index : 0,
       marker: {
         strokeColor: bgColor,
@@ -1151,7 +1152,7 @@ class ChartsCard extends LitElement {
       points.push({
         x: offset ? value[0] - offset : value[0],
         y: invert && value[1] ? -value[1] : value[1],
-        seriesIndex: index,
+        ...(stacked ? {} : { seriesIndex: index }),
         yAxisIndex: multiYAxis ? index : 0,
         marker: {
           size: 0,


### PR DESCRIPTION
Currently when using stacked: true and series that overlap the extremas are placed at the side of the column or...with more series added besides the colums (they shift further with more series)

![stacked_before](https://github.com/user-attachments/assets/88735719-59b1-4d93-b076-77e62a129ca5)

After the fix:
<img width="619" height="360" alt="image" src="https://github.com/user-attachments/assets/8be2de35-7d8d-4385-a0e6-ca00e5faa295" />

