### PR TITLE
Show extrema labels of negative values below the line

### DIFF
--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -1134,6 +1134,7 @@ class ChartsCard extends LitElement {
       label: {
         text: myFormatNumber(value[1], this._hass?.locale, serie.float_precision),
         borderColor: 'var(--card-background-color)',
+        offsetY: (value[1] ?? 0) < 0 ? 30 : 0,
         borderWidth: 2,
         style: {
           background: bgColor,
@@ -1164,7 +1165,7 @@ class ChartsCard extends LitElement {
         label: {
           text: `${Intl.DateTimeFormat(lang, options).format(value[0])}`,
           borderColor: 'var(--card-background-color)',
-          offsetY: -22,
+          offsetY: (value[1] ?? 0) < 0 ? 38 : -22,
           borderWidth: 0,
           style: {
             background: bgColorTime.toHexString(),


### PR DESCRIPTION
I've made a (small) change that, like the title states, puts the extrema labels of negative values below the graph line. 

Without advanced overlap detection there can't be a solution that is "the best" in every data situation, but this change follows the same idea of putting the label above the graph line for positive values. It's a position that is less likely to overlap the data.

My current implementation changes the default behavior. Some might consider this unacceptable, but it is at least a start for discussion or (other) ideas.

This relates to, but does not completely fixes #1010 (yet)