### PR TITLE
Add 'uix' option to types-config-ti

### DIFF
--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -41,6 +41,7 @@ export const ChartCardExternalConfig = t.iface([], {
   "header": t.opt("ChartCardHeaderExternalConfig"),
   "style": t.opt("any"),
   "card_mod": t.opt("any"),
+  "uix": t.opt("any"),
   "view_layout": t.opt("any"),
   "visibility": t.opt("any"),
   "grid_options": t.opt("any"),


### PR DESCRIPTION
allow new [Uix integration](https://uix.lf.technology) to add its domain key to the main config options.

see also issue https://github.com/RomRider/apexcharts-card/issues/997#issuecomment-3939776293