### PR TITLE
Add entity suggestion in the card picker for numeric entities

### DIFF
--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -1704,6 +1704,72 @@ return data.reverse();
 }
 
 // Configure the preview in the Lovelace card picker
+const NUMERIC_DOMAINS = ['counter', 'input_number', 'number'];
+
+const isNumericEntity = (hass: HomeAssistant, entityId: string): boolean => {
+  const domain = entityId.split('.')[0];
+  if (NUMERIC_DOMAINS.includes(domain)) return true;
+  if (domain !== 'sensor') return false;
+  const stateObj = hass.states[entityId];
+  if (!stateObj) return false;
+  return !!stateObj.attributes.unit_of_measurement || !!stateObj.attributes.state_class;
+};
+
+const getEntitySuggestion = (hass: HomeAssistant, entityId: string) => {
+  if (!isNumericEntity(hass, entityId)) return null;
+  const stateClass = hass.states[entityId]?.attributes.state_class;
+  if (stateClass === 'total' || stateClass === 'total_increasing') {
+    return [
+      {
+        label: 'Last 7 days',
+        config: {
+          type: 'custom:apexcharts-card',
+          graph_span: '7d',
+          span: { end: 'day' },
+          series: [{ entity: entityId, type: 'column', statistics: { type: 'change', period: 'day' } }],
+        },
+      },
+      {
+        label: 'Last 30 days',
+        config: {
+          type: 'custom:apexcharts-card',
+          graph_span: '30d',
+          span: { end: 'day' },
+          series: [{ entity: entityId, type: 'column', statistics: { type: 'change', period: 'day' } }],
+        },
+      },
+    ];
+  }
+  if (stateClass === 'measurement') {
+    return [
+      {
+        label: 'Last 24 hours',
+        config: {
+          type: 'custom:apexcharts-card',
+          graph_span: '24h',
+          series: [{ entity: entityId, statistics: { type: 'mean', period: 'hour' } }],
+        },
+      },
+      {
+        label: 'Last 7 days',
+        config: {
+          type: 'custom:apexcharts-card',
+          graph_span: '7d',
+          span: { end: 'day' },
+          series: [{ entity: entityId, statistics: { type: 'mean', period: 'day' } }],
+        },
+      },
+    ];
+  }
+  return {
+    config: {
+      type: 'custom:apexcharts-card',
+      graph_span: '24h',
+      series: [{ entity: entityId, group_by: { func: 'avg' } }],
+    },
+  };
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).customCards = (window as any).customCards || [];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1712,4 +1778,5 @@ return data.reverse();
   name: 'ApexCharts Card',
   preview: true,
   description: 'A graph card based on ApexCharts',
+  getEntitySuggestion,
 });


### PR DESCRIPTION
Home Assistant 2026.6 lets custom cards suggest themselves in the card picker when you select an entity. ApexCharts Card now shows up under the Community section for numeric entities (numeric sensors, plus counter, number and input_number helpers).

It proposes ready-to-use charts tuned to the entity. Meters (energy, water, gas) get consumption bars over the last 7 or 30 days, measurements get an averaged line over the last 24 hours or 7 days, and other numeric entities get a 24-hour line.

Docs: https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity

<img width="1019" height="722" alt="CleanShot 2026-06-03 at 12 12 39" src="https://github.com/user-attachments/assets/7c2b18bb-b96f-4c5c-91d6-3bbf909f9135" />

<img width="1019" height="722" alt="CleanShot 2026-06-03 at 12 12 33" src="https://github.com/user-attachments/assets/7f80bde6-4781-4e03-9edb-34d20fc6dcad" />
