### PR TITLE
add 'func:diff_inc' for grouping increasing data with resets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The position of the marker will only update when the card updates (state change 
 | `func` | string | `raw` | v1.0.0 | See [func](#func-options) |
 | `duration` | string | `1h` | v1.0.0 | If `func` is **not** `raw` only. It builds buckets of states over a `duration`. Doesn't work for months. Eg of valid values: `2h`, `1d`, `10s`, `25min`, `1h30`, ... |
 | `fill` | string | `last` | v1.0.0 | If `func` is **not** `raw` only. If there is any missing value in the buckets of history data (grouped by duration), `last` will replace them with the last non-empty state, `zero` will fill missing values with `0`, `'null'` will fill missing values with `null` |
-| `start_with_last` | boolean | `false` | v1.8.0 | If `true`, each bucket of data will start with the last value from the previous bucket of data. Mostly useful only with `func: diff` |
+| `start_with_last` | boolean | `false` | v1.8.0 | If `true`, each bucket of data will start with the last value from the previous bucket of data. Mostly useful only with `func: diff` and `func:diff_inc` |
 
 ### `func` Options
 
@@ -333,6 +333,7 @@ The position of the marker will only update when the card updates (state change 
 | `median` | v1.0.0 | Will return the median of all the states in each bucket |
 | `delta` | v1.0.0 | Will return the delta between the biggest and smallest state in each bucket |
 | `diff` | v1.4.0 | Will return the difference between the last and the first entry in the bucket |
+| `diff_inc` | v2.2.4 | Will return the difference between the last and the first entry in the bucket for increasing data with potential resets |
 
 ### `chart_type` Options
 

--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -70,6 +70,7 @@ export default class GraphEntry {
       median: this._median,
       delta: this._delta,
       diff: this._diff,
+      diff_inc: this._diff_inc,
     };
     this._index = index;
     this._cache = config.statistics ? false : cache;
@@ -626,6 +627,24 @@ export default class GraphEntry {
       return null;
     }
     return last - first;
+  }
+
+  private _diff_inc(items: EntityCachePoints): number | null {
+    const noNulls = this._filterNulls(items);
+    const first = this._first(noNulls);
+    const last = this._last(noNulls);
+    if (first === null || last === null) {
+      return null;
+    }
+    const min = this._minimum(noNulls);
+    if (min === null || min >= first) {
+      return last - first;
+    }
+    const max = this._maximum(noNulls);
+    if (max === null) {
+      return last - min
+    }
+    return (max - first) + (last - min);
   }
 
   private _filterNulls(items: EntityCachePoints): EntityCachePoints {

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -138,7 +138,7 @@ export const ChartCardPrettyTime = t.union(t.lit('millisecond'), t.lit('second')
 
 export const GroupByFill = t.union(t.lit('null'), t.lit('last'), t.lit('zero'));
 
-export const GroupByFunc = t.union(t.lit('raw'), t.lit('avg'), t.lit('min'), t.lit('max'), t.lit('last'), t.lit('first'), t.lit('sum'), t.lit('median'), t.lit('delta'), t.lit('diff'));
+export const GroupByFunc = t.union(t.lit('raw'), t.lit('avg'), t.lit('min'), t.lit('max'), t.lit('last'), t.lit('first'), t.lit('sum'), t.lit('median'), t.lit('delta'), t.lit('diff'), t.lit('diff_inc'));
 
 export const ChartCardHeaderExternalConfig = t.iface([], {
   "show": t.opt("boolean"),

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -140,7 +140,7 @@ export type ChartCardPrettyTime = 'millisecond' | 'second' | 'minute' | 'hour' |
 
 export type GroupByFill = 'null' | 'last' | 'zero';
 
-export type GroupByFunc = 'raw' | 'avg' | 'min' | 'max' | 'last' | 'first' | 'sum' | 'median' | 'delta' | 'diff';
+export type GroupByFunc = 'raw' | 'avg' | 'min' | 'max' | 'last' | 'first' | 'sum' | 'median' | 'delta' | 'diff' | 'diff_inc';
 
 export interface ChartCardHeaderExternalConfig {
   show?: boolean;

--- a/test/ui-lovelace.yaml
+++ b/test/ui-lovelace.yaml
@@ -226,6 +226,17 @@ views:
                 group_by:
                   duration: 10min
                   func: diff
+              - entity: sensor.random0_100
+                curve: smooth
+                name: DIFF_INC
+                type: line
+                show:
+                  as_duration: year
+                  in_header: true
+                  in_chart: false
+                group_by:
+                  duration: 10min
+                  func: diff_inc
 
           - type: custom:apexcharts-card
             graph_span: 4h


### PR DESCRIPTION
adds a new 'func: diff_inc' that returns max-first + last-min if bucket of increasing data has a reset.

This is required for home-assistant increasing sensors such as energy use.

This address issues with 'diff' per discussion #636 

 
<img width="627" height="256" alt="image" src="https://github.com/user-attachments/assets/42583248-32a8-4412-9191-30ea271fb8e4" />
