### PR TITLE
feat: rangeArea series type and `statistics: range` (rebase of #510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ However, some things might be broken :grin:
 - [Using the card](#using-the-card)
   - [Main Options](#main-options)
   - [`series` Options](#series-options)
+  - [`rangeArea` series](#rangearea-series)
   - [series' `show` Options](#series-show-options)
   - [`header_actions` or `title_actions` options](#header_actions-or-title_actions-options)
   - [`*_action` options](#_action-options)
@@ -166,10 +167,10 @@ The card strictly validates all the options available (but not for the `apex_con
 | `name` | string | | v1.0.0 | Override the name of the entity |
 | `stack_group` | string | | v2.1.0 | When `stacked` is `true`, groups the different series with the name `stack_group` together. Only works for `type: column`. All series' names need to be be unique because of a bug in apexcharts.js |
 | `color` | string | | v1.1.0 | Color of the serie. Supported formats: `yellow`, `#aabbcc`, `rgb(128, 128, 128)` or `var(--css-color-variable)` |
-| `opacity` | number | `0.7` for `area`<br/>else `1` | v1.6.0 | The opacity of the line or filled area, between `0` and `1` |
-| `stroke_width` | number | `5` | v1.6.0 | Change the width of the line. Only works for `area` and `line` |
+| `opacity` | number | `0.7` for `area` and `rangeArea`<br/>else `1` | v1.6.0 | The opacity of the line or filled area, between `0` and `1` |
+| `stroke_width` | number | `5` | v1.6.0 | Change the width of the line. Only works for `area`, `line` and `rangeArea` (`0` leaves a `rangeArea` with no outline) |
 | `stroke_dash` | number or array | `0` | v2.1.0 | Creates a dashed line. The higher the number, the bigger the dash. An array can be used to specify more complex patterns. |
-| `type` | string | `line` | v1.0.0 | `line`, `area` or `column` are supported for now |
+| `type` | string | `line` | v1.0.0 | `line`, `area`, `column` or `rangeArea` are supported for now. `rangeArea` fills the band between a low and a high value and expects each data point to be `[timestamp, [low, high]]` — see [`rangeArea` series](#rangearea-series) |
 | `curve` | string | `smooth` | v1.0.0 | `smooth` (nice curve),  `straight` (direct line between points) or `stepline` (flat line until next point then straight up or down), `monotoneCubic` (create a monotone cubic spline) |
 | ~~`extend_to_end`~~ | ~~boolean~~ | ~~`true`~~ | ~~v1.0.0~~ | **DEPRECATED since v2.0.0** ~~If the last data is older than the end time displayed on the graph, setting to true will extend the value until the end of the timeline. Only works for `line` and `area` types.~~ |
 | `extend_to` | boolean or string | `end` | v2.0.0 | If the value is `end`, it will extend the line/area to the end of the chart. With `now`, it will extend it to the current time (usefull for chart showing current and future data). If `false` it will not do anything. Only available for `line` and `area` types. |
@@ -189,6 +190,68 @@ The card strictly validates all the options available (but not for the `apex_con
 | `yaxis_id` | string | | v1.9.0 | The identification name of the y-axis to which this series should be associated. See [yaxis](#yaxis-options-multi-y-axis) |
 | `show` | object | | v1.3.0 | See [serie's show options](#series-show-options) |
 | `header_actions` | object | | v1.10.0 | See [header_actions](#header_actions-or-title_actions-options) |
+
+### `rangeArea` series
+
+A `rangeArea` series fills the band between a low and a high value instead of
+drawing a single line. Each data point is `[timestamp, [low, high]]`.
+
+The usual case is a daily minimum and maximum with the mean as a line through
+it, which `statistics: {type: range}` produces directly:
+
+```yaml
+type: custom:apexcharts-card
+graph_span: 30d
+series:
+  - entity: sensor.outside_temperature
+    name: Range
+    type: rangeArea
+    opacity: 0.25
+    stroke_width: 0
+    statistics:
+      type: range
+      period: day
+  - entity: sensor.outside_temperature
+    name: Mean
+    type: line
+    statistics:
+      type: mean
+      period: day
+```
+
+A `data_generator` can feed one just as well, as long as every point is a pair.
+Note that `data_generator` replaces the card's own fetching, so the data has to
+come from somewhere you reach yourself — `hass.callWS` for statistics, for
+instance:
+
+```yaml
+    data_generator: |
+      const res = await hass.callWS({
+        type: 'recorder/statistics_during_period',
+        start_time: start.toISOString(),
+        end_time: end.toISOString(),
+        statistic_ids: [entity.entity_id],
+        period: 'day',
+      });
+      return (res[entity.entity_id] || []).map((r) => [new Date(r.start).getTime(), [r.min, r.max]]);
+```
+
+`group_by` is not meaningful on a range: its aggregators reduce a band to a
+single number, and `fill: null` would write a bare `null` where a pair is
+required. Leave it at its default for `rangeArea` series.
+
+Three things are worth knowing:
+
+- **Missing points must be `[null, null]`, not `null`.** ApexCharts reads
+  index `0` of every point in a range series and throws on a plain `null`,
+  which leaves the whole chart blank.
+- **A band scales by its high edge, and a `min` by its low.** ApexCharts works
+  this out on its own, and so does a configured `yaxis` block, so a band is
+  never clipped at the top by its own mean.
+- **Mixing a `rangeArea` with lines changes the tooltip.** ApexCharts renders
+  every row as `low - high` as soon as one series is a range, so a line shows
+  up as `null - null`. Use `apex_config.tooltip.custom` if you need both kinds
+  in one tooltip.
 
 ### series' `show` Options
 
@@ -274,7 +337,7 @@ series:
 
 | Name | Type | Default | Since | Description |
 | ---- | :--: | :-----: | :---: | ----------- |
-| `type` | string | `mean` | v2.0.0 | Type of long term statistic to pull. Can be one of `min`, `max`, `mean`, `sum` `state` or `change` |
+| `type` | string | `mean` | v2.0.0 | Type of long term statistic to pull. Can be one of `min`, `max`, `mean`, `sum`, `state`, `change` or `range`. `range` yields the `[min, max]` pair of each bucket and is meant for a `rangeArea` series |
 | `period` | string | `hour` | v2.0.0 | Period of statistics to pull. Can be one of `5minute`, `hour`, `day`, `week` or `month` |
 | `align` | string | `middle` | v2.0.0 | Align the data points to the `start`, `end` or `middle` of the period of the statistics |
 
@@ -339,7 +402,8 @@ The position of the marker will only update when the card updates (state change 
 
 | Name | Since | Description |
 | ---- | :---: | ----------- |
-| `line` | v1.0.0 | This is the default and will show a timeline. It is compatible with `series.type` = `column`, `line` and `area` |
+| `line` | v1.0.0 | This is the default and will show a timeline. It is compatible with `series.type` = `column`, `line`, `area` and `rangeArea` |
+| `rangeArea` | vNEXT | A timeline of bands only. Only needed when EVERY series is a `rangeArea` — a chart mixing bands with lines should stay on `line`, or ApexCharts switches to its range tooltip, which shows a single series and no shared rows. See [`rangeArea` series](#rangearea-series) |
 | `scatter` | v1.4.0 | Displays a cloud of points without a line between the values |
 | `pie` | v1.4.0 | This will display a pie chart with the last value computed for each sensor |
 | `donut` | v1.4.0 | This will display a donut chart with the last value computed of each sensor, the same as pie but with a hole in the center |

--- a/src/apex-layouts.ts
+++ b/src/apex-layouts.ts
@@ -92,6 +92,15 @@ export function getLayoutConfig(
     },
   };
 
+  // Only when EVERY series is a range. Forcing `rangeArea` on a MIXED chart
+  // switches ApexCharts to its range tooltip: a single series, no shared rows,
+  // and the x-axis formatter is handed something that is not a timestamp, so a
+  // configured `tooltip.x.format` renders as NaN.NaN.NaN. A mixed chart does
+  // not need the switch - ApexCharts draws a rangeArea series correctly from
+  // the per-series `type` alone.
+  if (def.chart.type === 'line' && def.series.length > 0 && def.series.every((s) => s.type === 'rangeArea'))
+    def.chart.type = 'rangeArea';
+
   let conf = {};
   switch (config.layout) {
     case 'minimal':
@@ -176,13 +185,22 @@ export function getBrushLayoutConfig(
       text: 'Loading...',
     },
   };
+
+  // Same condition as in getLayoutConfig above.
+  if (def.chart.type === 'line' && def.series.length > 0 && def.series.every((s) => s.type === 'rangeArea'))
+    def.chart.type = 'rangeArea';
+
   return config.brush?.apex_config ? mergeDeep(def, evalApexConfig(config.brush.apex_config)) : def;
 }
 
 function getFillOpacity(config: ChartCardConfig, brush: boolean): number[] {
   const series = brush ? config.series_in_brush : config.series_in_graph;
   return series.map((serie) => {
-    return serie.opacity !== undefined ? serie.opacity : serie.type === 'area' ? DEFAULT_AREA_OPACITY : 1;
+    return serie.opacity !== undefined
+      ? serie.opacity
+      : serie.type === 'area' || serie.type === 'rangeArea'
+        ? DEFAULT_AREA_OPACITY
+        : 1;
   });
 }
 
@@ -194,7 +212,9 @@ function getSeries(config: ChartCardConfig, hass: HomeAssistant | undefined, bru
         name: computeName(index, series, undefined, hass?.states[serie.entity]),
         group: config.stacked && serie.type === 'column' ? serie.stack_group : undefined,
         type: serie.type,
-        data: [],
+        // A rangeArea needs a [low, high] shaped seed, or ApexCharts throws
+        // while measuring the empty series before any data has arrived.
+        data: (serie.type ?? config.chart_type) === 'rangeArea' ? [[0, [0, 0]]] : [],
       };
     });
   } else {
@@ -278,6 +298,7 @@ function getXTooltipFormatter(
         } as any).format(val);
       }
     : function (val, _a, _b, hours_12 = hours12) {
+        if (!val) return '';
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return new Intl.DateTimeFormat(lang, {
           year: 'numeric',
@@ -294,6 +315,7 @@ function getXTooltipFormatter(
 
 function getYTooltipFormatter(config: ChartCardConfig, hass: HomeAssistant | undefined) {
   return function (value, opts, conf = config, hass2 = hass) {
+    if (!opts) return value;
     let lValue = value;
     if (conf.series_in_graph[opts.seriesIndex]?.invert && lValue) {
       lValue = -lValue;
@@ -477,14 +499,14 @@ function getDataLabels_enabledOnSeries(config: ChartCardConfig) {
 }
 
 function getStrokeWidth(config: ChartCardConfig, brush: boolean) {
-  if (config.chart_type !== undefined && config.chart_type !== 'line')
+  if (config.chart_type !== undefined && config.chart_type !== 'line' && config.chart_type !== 'rangeArea')
     return config.apex_config?.stroke?.width === undefined ? 3 : config.apex_config?.stroke?.width;
   const series = brush ? config.series_in_brush : config.series_in_graph;
   return series.map((serie) => {
     if (serie.stroke_width !== undefined) {
       return serie.stroke_width;
     }
-    return [undefined, 'line', 'area'].includes(serie.type) ? 5 : 0;
+    return [undefined, 'line', 'area', 'rangeArea'].includes(serie.type) ? 5 : 0;
   });
 }
 

--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -40,6 +40,8 @@ import {
   getLovelace,
   isUsingServerTimezone,
   computeTimezoneDiffWithLocal,
+  negateStateValue,
+  rangeEdge,
 } from './utils';
 import ApexCharts from 'apexcharts';
 import { Ripple } from '@material/mwc-ripple';
@@ -852,7 +854,7 @@ class ChartsCard extends LitElement {
               );
             } else {
               // not raw
-              this._headerState[index] = graph.lastState;
+              this._headerState[index] = Array.isArray(graph.lastState) ? graph.lastState[0] : graph.lastState;
             }
           }
           if (!this._config?.series[index].show.in_chart && !this._config?.series[index].show.in_brush) {
@@ -915,7 +917,7 @@ class ChartsCard extends LitElement {
               }
               data = 0;
             } else {
-              const lastState = graph.lastState;
+              const lastState = Array.isArray(graph.lastState) ? graph.lastState[0] : graph.lastState;
               data = lastState || 0;
               if (this._config?.series[index].show.in_header !== 'raw') {
                 this._headerState[index] = lastState;
@@ -953,7 +955,7 @@ class ChartsCard extends LitElement {
           gradient: {
             type: 'vertical',
             colorStops: this._config.series_in_graph.map((serie, index) => {
-              if (!serie.color_threshold || ![undefined, 'area', 'line'].includes(serie.type)) return [];
+              if (!serie.color_threshold || ![undefined, 'area', 'rangeArea', 'line'].includes(serie.type)) return [];
               const min = this._graphs?.[serie.index]?.min;
               const max = this._graphs?.[serie.index]?.max;
               if (min === undefined || max === undefined) return [];
@@ -968,7 +970,7 @@ class ChartsCard extends LitElement {
             gradient: {
               type: 'vertical',
               colorStops: this._config.series_in_brush.map((serie, index) => {
-                if (!serie.color_threshold || ![undefined, 'area', 'line'].includes(serie.type)) return [];
+                if (!serie.color_threshold || ![undefined, 'area', 'rangeArea', 'line'].includes(serie.type)) return [];
                 const min = this._graphs?.[serie.index]?.min;
                 const max = this._graphs?.[serie.index]?.max;
                 if (min === undefined || max === undefined) return [];
@@ -1083,6 +1085,7 @@ class ChartsCard extends LitElement {
               serie.invert,
               sameDay,
               withTime,
+              'low',
             ),
           );
         }
@@ -1120,7 +1123,12 @@ class ChartsCard extends LitElement {
     invert = false,
     sameDay: boolean,
     withTime: boolean,
+    // Which edge of a range this extreme sits on. Without it the annotation
+    // received the [low, high] pair itself: an invalid `y`, and NaN once
+    // `invert` negated it.
+    edge: 'low' | 'high' = 'high',
   ) {
+    const extremaValue = rangeEdge(value[1], edge);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const points: any = [];
     const multiYAxis =
@@ -1129,7 +1137,7 @@ class ChartsCard extends LitElement {
       this._config.apex_config.yaxis.length > 1;
     points.push({
       x: offset ? value[0] - offset : value[0],
-      y: invert && value[1] ? -value[1] : value[1],
+      y: invert && extremaValue ? -extremaValue : extremaValue,
       seriesIndex: index,
       yAxisIndex: multiYAxis ? index : 0,
       marker: {
@@ -1137,7 +1145,7 @@ class ChartsCard extends LitElement {
         fillColor: 'var(--card-background-color)',
       },
       label: {
-        text: myFormatNumber(value[1], this._hass?.locale, serie.float_precision),
+        text: myFormatNumber(extremaValue, this._hass?.locale, serie.float_precision),
         borderColor: 'var(--card-background-color)',
         borderWidth: 2,
         style: {
@@ -1160,7 +1168,7 @@ class ChartsCard extends LitElement {
       const lang = getLang(this._config, this._hass);
       points.push({
         x: offset ? value[0] - offset : value[0],
-        y: invert && value[1] ? -value[1] : value[1],
+        y: invert && extremaValue ? -extremaValue : extremaValue,
         seriesIndex: index,
         yAxisIndex: multiYAxis ? index : 0,
         marker: {
@@ -1221,13 +1229,15 @@ class ChartsCard extends LitElement {
           );
           if (!lMinMax) return undefined;
           if (this._config?.series[id].invert) {
-            const cmin = lMinMax.min[1];
-            const cmax = lMinMax.max[1];
+            // A range flips end for end - the negated high becomes the new low.
+            // Negating the pair itself yields NaN.
+            const cmin = negateStateValue(lMinMax.min[1]);
+            const cmax = negateStateValue(lMinMax.max[1]);
             if (cmin !== null) {
-              lMinMax.max[1] = -cmin;
+              lMinMax.max[1] = cmin;
             }
             if (cmax !== null) {
-              lMinMax.min[1] = -cmax;
+              lMinMax.min[1] = cmax;
             }
           }
           return lMinMax;
@@ -1236,15 +1246,20 @@ class ChartsCard extends LitElement {
         let max: number | null = null;
         minMax?.forEach((elt) => {
           if (!elt) return;
+          // Not Math.min/max over the raw pair: a half-known band carries a null
+          // edge, and Math.min(null, x) coerces it to 0, dragging the axis to
+          // zero. rangeEdge picks the meaningful edge and leaves null as null.
+          const val_min = rangeEdge(elt.min[1], 'low');
+          const val_max = rangeEdge(elt.max[1], 'high');
           if (min === undefined || min === null) {
-            min = elt.min[1];
-          } else if (elt.min[1] !== null && min > elt.min[1]) {
-            min = elt.min[1];
+            min = val_min;
+          } else if (val_min !== null && min > val_min) {
+            min = val_min;
           }
           if (max === undefined || max === null) {
-            max = elt.max[1];
-          } else if (elt.max[1] !== null && max < elt.max[1]) {
-            max = elt.max[1];
+            max = val_max;
+          } else if (val_max !== null && max < val_max) {
+            max = val_max;
           }
         });
         if (yaxis.align_to !== undefined) {
@@ -1368,7 +1383,12 @@ class ChartsCard extends LitElement {
         return [];
       }
       let color: string | undefined = undefined;
-      const defaultOp = serie.opacity !== undefined ? serie.opacity : serie.type === 'area' ? DEFAULT_AREA_OPACITY : 1;
+      const defaultOp =
+        serie.opacity !== undefined
+          ? serie.opacity
+          : serie.type === 'area' || serie.type === 'rangeArea'
+          ? DEFAULT_AREA_OPACITY
+          : 1;
       let opacity = thres.opacity === undefined ? defaultOp : thres.opacity;
       if (thres.value > max && arr[index - 1]) {
         const factor = (max - arr[index - 1].value) / (thres.value - arr[index - 1].value);
@@ -1492,7 +1512,7 @@ class ChartsCard extends LitElement {
   private _invertData(data: EntityCachePoints): EntityCachePoints {
     return data.map((item) => {
       if (item[1] === null) return item;
-      return [item[0], -item[1]];
+      return [item[0], negateStateValue(item[1])];
     });
   }
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -44,7 +44,7 @@ export const DEFAULT_COLORS = [
 ];
 
 export const NO_VALUE = 'N/A';
-export const TIMESERIES_TYPES = ['line', 'scatter', undefined];
+export const TIMESERIES_TYPES = ['rangeArea', 'line', 'scatter', undefined];
 export const PLAIN_COLOR_TYPES = ['scatter', 'radialBar', 'pie', 'donut'];
 
 export const DEFAULT_MIN = 0;

--- a/src/graphEntry.ts
+++ b/src/graphEntry.ts
@@ -7,6 +7,8 @@ import {
   HassHistoryEntry,
   HistoryBuckets,
   HistoryPoint,
+  RangeValue,
+  StateValue,
   Statistics,
   StatisticValue,
 } from './types';
@@ -19,6 +21,24 @@ import parse from 'parse-duration';
 import SparkMD5 from 'spark-md5';
 import { ChartCardSpanExtConfig, StatisticsPeriod } from './types-config';
 import * as pjson from '../package.json';
+
+function midpoint(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return (a + b) / 2;
+}
+
+// A range point carries [low, high]; a plain one is both its own low and high.
+// Comparing StateValue directly with </> silently falls back to Array-to-string
+// comparison ("9,10" < "10,30" is false), which is what made minMaxWithTimestamp
+// pick the wrong points.
+function rangeLow(value: StateValue): number | null {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function rangeHigh(value: StateValue): number | null {
+  return Array.isArray(value) ? value[1] : value;
+}
 
 export default class GraphEntry {
   private _computedHistory?: EntityCachePoints;
@@ -110,7 +130,7 @@ export default class GraphEntry {
     this._cache = this._config.statistics ? false : cache;
   }
 
-  get lastState(): number | null {
+  get lastState(): StateValue {
     return this.history.length > 0 ? this.history[this.history.length - 1][1] : null;
   }
 
@@ -122,17 +142,26 @@ export default class GraphEntry {
       return false;
     });
     if (index === -1) return null;
-    return this.history[index][1];
+    return rangeLow(this.history[index][1]);
+  }
+
+  // BOTH edges of a range, so `min`/`max` describe the band rather than just
+  // its underside. Those getters feed the color_threshold gradient stops.
+  private flatMapper(item: HistoryPoint): number[] {
+    if (Array.isArray(item[1])) {
+      return item[1].filter((value): value is number => value !== null);
+    }
+    return item[1] === null ? [] : [item[1]];
   }
 
   get min(): number | undefined {
     if (!this._computedHistory || this._computedHistory.length === 0) return undefined;
-    return Math.min(...this._computedHistory.flatMap((item) => (item[1] === null ? [] : [item[1]])));
+    return Math.min(...this._computedHistory.flatMap(this.flatMapper));
   }
 
   get max(): number | undefined {
     if (!this._computedHistory || this._computedHistory.length === 0) return undefined;
-    return Math.max(...this._computedHistory.flatMap((item) => (item[1] === null ? [] : [item[1]])));
+    return Math.max(...this._computedHistory.flatMap(this.flatMapper));
   }
 
   public minMaxWithTimestamp(
@@ -147,8 +176,12 @@ export default class GraphEntry {
       (acc: { min: HistoryPoint; max: HistoryPoint }, point) => {
         if (point[1] === null) return acc;
         if (point[0] > end || point[0] < start) return acc;
-        if (acc.max[1] === null || acc.max[1] < point[1]) acc.max = [...point];
-        if (acc.min[1] === null || (point[1] !== null && acc.min[1] > point[1])) acc.min = [...point];
+        const pointHigh = rangeHigh(point[1]);
+        const accHigh = rangeHigh(acc.max[1]);
+        if (accHigh === null || (pointHigh !== null && accHigh < pointHigh)) acc.max = [...point];
+        const pointLow = rangeLow(point[1]);
+        const accLow = rangeLow(acc.min[1]);
+        if (accLow === null || (pointLow !== null && accLow > pointLow)) acc.min = [...point];
         return acc;
       },
       { min: [0, null], max: [0, null] },
@@ -200,7 +233,7 @@ export default class GraphEntry {
     this._updating = true;
 
     if (this._config.ignore_history) {
-      let currentState: null | number | string = null;
+      let currentState: StateValue | string = null;
       if (this._config.attribute) {
         currentState = this._entityState.attributes?.[this._config.attribute];
       } else {
@@ -267,17 +300,20 @@ export default class GraphEntry {
         const newHistory = await this._fetchStatistics(fetchStart, fetchEnd, this._config.statistics.period);
         if (newHistory && newHistory.length > 0) {
           updateGraphHistory = true;
-          let lastNonNull: number | null = null;
+          let lastNonNull: StateValue = null;
           if (history && history.data && history.data.length > 0) {
             lastNonNull = history.data[history.data.length - 1][1];
           }
           newStateHistory = newHistory.map((item) => {
-            let stateParsed: number | null = null;
-            [lastNonNull, stateParsed] = this._transformAndFill(
-              item[this._config.statistics?.type || DEFAULT_STATISTICS_TYPE],
-              item,
-              lastNonNull,
-            );
+            let stateParsed: StateValue = null;
+            if (this._config.statistics?.type === 'range')
+              [lastNonNull, stateParsed] = this._transformAndFill([item.min, item.max], item, lastNonNull);
+            else
+              [lastNonNull, stateParsed] = this._transformAndFill(
+                item[this._config.statistics?.type || DEFAULT_STATISTICS_TYPE],
+                item,
+                lastNonNull,
+              );
 
             let displayDate: Date | null = null;
             const startDate = new Date(item.start);
@@ -317,12 +353,13 @@ export default class GraphEntry {
           if ((this._config.attribute || this._config.transform) && skipInitialState) {
             newHistory[0].shift();
           }
-          let lastNonNull: number | null = null;
+          let lastNonNull: StateValue = null;
           if (history && history.data && history.data.length > 0) {
             lastNonNull = history.data[history.data.length - 1][1];
           }
           newStateHistory = newHistory[0].map((item) => {
-            let currentState: unknown = null;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let currentState: any = null;
             if (this._config.attribute) {
               if (item.attributes && item.attributes[this._config.attribute] !== undefined) {
                 currentState = item.attributes[this._config.attribute];
@@ -330,7 +367,7 @@ export default class GraphEntry {
             } else {
               currentState = item.state;
             }
-            let stateParsed: number | null = null;
+            let stateParsed: StateValue = null;
             [lastNonNull, stateParsed] = this._transformAndFill(currentState, item, lastNonNull);
 
             if (this._config.attribute) {
@@ -377,8 +414,9 @@ export default class GraphEntry {
       const res: EntityCachePoints = this._dataBucketer(history, moment.range(startHistory, end)).map((bucket) => {
         return [bucket.timestamp, this._func(bucket.data)];
       });
-      if ([undefined, 'line', 'area'].includes(this._config.type)) {
-        while (res.length > 0 && res[0][1] === null) res.shift();
+      if ([undefined, 'line', 'area', 'rangeArea'].includes(this._config.type)) {
+        while (res.length > 0 && (res[0][1] === null || (Array.isArray(res[0][1]) && res[0][1][0] === null)))
+          res.shift();
       }
       this._computedHistory = res;
     } else {
@@ -388,14 +426,7 @@ export default class GraphEntry {
     return true;
   }
 
-  private _transformAndFill(
-    currentState: unknown,
-    item: HassHistoryEntry | StatisticValue,
-    lastNonNull: number | null,
-  ): [number | null, number | null] {
-    if (this._config.transform) {
-      currentState = this._applyTransform(currentState, item);
-    }
+  private _lastNonNull(currentState: unknown, lastNonNull: number | null): [number | null, number | null] {
     let stateParsed: number | null = parseFloat(currentState as string);
     stateParsed = !Number.isNaN(stateParsed) ? stateParsed : null;
     if (stateParsed === null) {
@@ -410,7 +441,30 @@ export default class GraphEntry {
     return [lastNonNull, stateParsed];
   }
 
-  private _applyTransform(value: unknown, historyItem: HassHistoryEntry | StatisticValue): number | null {
+  private _transformAndFill(
+    currentState: string | boolean | number | null | [unknown, unknown],
+    item: HassHistoryEntry | StatisticValue,
+    lastNonNull: StateValue,
+  ): [StateValue, StateValue] {
+    if (this._config.transform) {
+      currentState = this._applyTransform(currentState, item);
+    }
+    if (Array.isArray(currentState)) {
+      const stateParsed: RangeValue = [null, null];
+      // Not just `=== null`: a transform may return a pair for some points and a
+      // scalar for others, and indexing a primitive throws in strict mode.
+      if (!Array.isArray(lastNonNull)) lastNonNull = [null, null];
+      // A RangeValue is a 2-tuple. Running to 3 appended a third element to
+      // every point, so they no longer matched their own declared type.
+      for (let i = 0; i < 2; ++i) {
+        [lastNonNull[i], stateParsed[i]] = this._lastNonNull(currentState[i], lastNonNull[i]);
+      }
+      return [lastNonNull, stateParsed];
+    }
+    return this._lastNonNull(currentState, <number | null>lastNonNull);
+  }
+
+  private _applyTransform(value: unknown, historyItem: HassHistoryEntry | StatisticValue): StateValue {
     return new Function('x', 'hass', 'entity', `'use strict'; ${this._config.transform}`).call(
       this,
       value,
@@ -504,7 +558,7 @@ export default class GraphEntry {
         return false;
       });
     });
-    let lastNonNullBucketValue: number | null = null;
+    let lastNonNullBucketValue: StateValue = null;
     const now = new Date().getTime();
     buckets.forEach((bucket, index) => {
       if (bucket.data.length === 0) {
@@ -555,10 +609,10 @@ export default class GraphEntry {
       let val = 0;
       if (entry && entry[1] === null) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        val = items[lastIndex][1]!;
+        val = (Array.isArray(items[lastIndex][1]) ? items[lastIndex][1]![0] : items[lastIndex][1])!;
       } else {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        val = entry[1]!;
+        val = (Array.isArray(entry[1]) ? entry[1][0] : entry[1])!;
         lastIndex = index;
       }
       return sum + val;
@@ -574,9 +628,10 @@ export default class GraphEntry {
   private _minimum(items: EntityCachePoints): number | null {
     let min: number | null = null;
     items.forEach((item) => {
-      if (item[1] !== null)
-        if (min === null) min = item[1];
-        else min = Math.min(item[1], min);
+      const val = rangeLow(item[1]);
+      if (val !== null)
+        if (min === null) min = val;
+        else min = Math.min(val, min);
     });
     return min;
   }
@@ -584,32 +639,44 @@ export default class GraphEntry {
   private _maximum(items: EntityCachePoints): number | null {
     let max: number | null = null;
     items.forEach((item) => {
-      if (item[1] !== null)
-        if (max === null) max = item[1];
-        else max = Math.max(item[1], max);
+      // The HIGH edge - the maximum of a band is its top, not its underside.
+      const val = rangeHigh(item[1]);
+      if (val !== null)
+        if (max === null) max = val;
+        else max = Math.max(val, max);
     });
     return max;
   }
 
   private _last(items: EntityCachePoints): number | null {
     if (items.length === 0) return null;
-    return items.slice(-1)[0][1];
+    const lastSlice = items.slice(-1)[0][1];
+    return Array.isArray(lastSlice) ? lastSlice[0] : lastSlice;
   }
 
   private _first(items: EntityCachePoints): number | null {
     if (items.length === 0) return null;
-    return items[0][1];
+    const firstSlice = items[0][1];
+    return Array.isArray(firstSlice) ? firstSlice[0] : firstSlice;
   }
 
   private _median(items: EntityCachePoints) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const itemsDup = this._filterNulls([...items]).sort((a, b) => a[1]! - b[1]!);
+    const itemsDup = this._filterNulls([...items]).sort((a, b) => rangeLow(a[1])! - rangeLow(b[1])!);
     if (itemsDup.length === 0) return null;
     if (itemsDup.length === 1) return itemsDup[0][1];
     const mid = Math.floor((itemsDup.length - 1) / 2);
     if (itemsDup.length % 2 === 1) return itemsDup[mid][1];
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return (itemsDup[mid][1]! + itemsDup[mid + 1][1]!) / 2;
+
+    const lower = itemsDup[mid][1];
+    const upper = itemsDup[mid + 1][1];
+    // Element-wise for a range, so an even-length bucket returns the same
+    // SHAPE as an odd-length one. Previously it returned a bare number there,
+    // and `a + b / 2` on top of that - missing parentheses, so roughly 1.5x.
+    if (Array.isArray(lower) && Array.isArray(upper)) {
+      return [midpoint(lower[0], upper[0]), midpoint(lower[1], upper[1])] as RangeValue;
+    }
+    return midpoint(<number | null>lower, <number | null>upper);
   }
 
   private _delta(items: EntityCachePoints): number | null {

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -50,7 +50,7 @@ export const ChartCardExternalConfig = t.iface([], {
   "yaxis": t.opt(t.array("ChartCardYAxisExternal")),
 });
 
-export const ChartCardChartType = t.union(t.lit('line'), t.lit('scatter'), t.lit('pie'), t.lit('donut'), t.lit('radialBar'));
+export const ChartCardChartType = t.union(t.lit('line'), t.lit('scatter'), t.lit('pie'), t.lit('donut'), t.lit('radialBar'), t.lit('rangeArea'));
 
 export const ChartCardBrushExtConfig = t.iface([], {
   "selection_span": t.opt("string"),
@@ -71,7 +71,7 @@ export const ChartCardAllSeriesExternalConfig = t.iface([], {
   "entity": t.opt("string"),
   "attribute": t.opt("string"),
   "name": t.opt("string"),
-  "type": t.opt(t.union(t.lit('line'), t.lit('column'), t.lit('area'))),
+  "type": t.opt(t.union(t.lit('line'), t.lit('column'), t.lit('area'), t.lit('rangeArea'))),
   "stack_group": t.opt("string"),
   "color": t.opt("string"),
   "opacity": t.opt("number"),
@@ -83,7 +83,7 @@ export const ChartCardAllSeriesExternalConfig = t.iface([], {
   "invert": t.opt("boolean"),
   "data_generator": t.opt("string"),
   "statistics": t.opt(t.iface([], {
-    "type": t.opt(t.union(t.lit('mean'), t.lit('max'), t.lit('min'), t.lit('sum'), t.lit('state'), t.lit('change'))),
+    "type": t.opt(t.union(t.lit('mean'), t.lit('max'), t.lit('min'), t.lit('sum'), t.lit('state'), t.lit('change'), t.lit('range'))),
     "period": t.opt("StatisticsPeriod"),
     "align": t.opt(t.union(t.lit('start'), t.lit('end'), t.lit('middle'))),
   })),

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -51,7 +51,7 @@ export interface ChartCardExternalConfig {
   yaxis?: ChartCardYAxisExternal[];
 }
 
-export type ChartCardChartType = 'line' | 'scatter' | 'pie' | 'donut' | 'radialBar';
+export type ChartCardChartType = 'line' | 'scatter' | 'pie' | 'donut' | 'radialBar' | 'rangeArea';
 
 export interface ChartCardBrushExtConfig {
   selection_span?: string;
@@ -73,7 +73,7 @@ export interface ChartCardAllSeriesExternalConfig {
   entity?: string;
   attribute?: string;
   name?: string;
-  type?: 'line' | 'column' | 'area';
+  type?: 'line' | 'column' | 'area' | 'rangeArea';
   stack_group?: string;
   color?: string;
   opacity?: number;
@@ -85,7 +85,7 @@ export interface ChartCardAllSeriesExternalConfig {
   invert?: boolean;
   data_generator?: string;
   statistics?: {
-    type?: 'mean' | 'max' | 'min' | 'sum' | 'state' | 'change';
+    type?: 'mean' | 'max' | 'min' | 'sum' | 'state' | 'change' | 'range';
     period?: StatisticsPeriod;
     align?: 'start' | 'end' | 'middle';
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,9 +49,13 @@ export interface EntityEntryCache {
   data: EntityCachePoints;
 }
 
+export type StateValue = RangeValue | number | null;
+
+export type RangeValue = [number | null, number | null];
+
 export type EntityCachePoints = Array<HistoryPoint>;
 
-export type HistoryPoint = [number, number | null];
+export type HistoryPoint = [number, StateValue];
 
 export interface Statistics {
   [statisticId: string]: StatisticValue[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,29 @@
 import { HassEntities, HassEntity } from 'home-assistant-js-websocket';
 import { compress as lzStringCompress, decompress as lzStringDecompress } from 'lz-string';
-import { ChartCardConfig, EntityCachePoints } from './types';
+import { ChartCardConfig, EntityCachePoints, RangeValue, StateValue } from './types';
 import { TinyColor } from '@ctrl/tinycolor';
 import parse from 'parse-duration';
 import { ChartCardExternalConfig, ChartCardPrettyTime, ChartCardSeriesExternalConfig } from './types-config';
 import { DEFAULT_FLOAT_PRECISION, DEFAULT_MAX, DEFAULT_MIN, moment, NO_VALUE } from './const';
 import { formatNumber, FrontendLocaleData, HomeAssistant } from 'custom-card-helpers';
 import { OverrideFrontendLocaleData } from './types-ha';
+
+// The edge of a range that a given extreme lives on: a maximum sits on the
+// high edge, a minimum on the low one. A plain value is both.
+export function rangeEdge(value: StateValue, edge: 'low' | 'high'): number | null {
+  if (!Array.isArray(value)) return value;
+  return edge === 'high' ? value[1] : value[0];
+}
+
+// Negating a range flips it end for end: the negated high becomes the new low.
+// `-value` on the pair itself yields NaN.
+export function negateStateValue(value: StateValue): StateValue {
+  if (value === null) return null;
+  if (Array.isArray(value)) {
+    return [value[1] === null ? null : -value[1], value[0] === null ? null : -value[0]];
+  }
+  return -value;
+}
 
 export function compress(data: unknown): string {
   return lzStringCompress(JSON.stringify(data));
@@ -310,18 +327,19 @@ export function truncateFloat(
 }
 
 export function myFormatNumber(
-  num: string | number | null | undefined,
+  num: string | number | null | undefined | RangeValue,
   localeOptions?: FrontendLocaleData,
   precision?: number | undefined,
 ): string | null {
-  let lValue: string | number | null | undefined = num;
-  if (lValue === undefined || lValue === null) return null;
+  let lValue: string | number | null | undefined | RangeValue = num;
   if (typeof lValue === 'string') {
     lValue = parseFloat(lValue);
     if (Number.isNaN(lValue)) {
       return num as string;
     }
   }
+  if (Array.isArray(lValue)) lValue = lValue[0];
+  if (lValue === undefined || lValue === null) return null;
   return formatNumber(lValue, localeOptions, {
     minimumFractionDigits: precision === undefined ? 0 : precision,
     maximumFractionDigits: precision === undefined ? DEFAULT_FLOAT_PRECISION : precision,


### PR DESCRIPTION
Rebase of #510 by @Buddy-Matt onto current `dev`, with documentation and fixes
for several defects the original carried. That PR branched off in December 2022
and `dev` has moved 74 commits since; this is the same feature applied to
`59dea8fb`.

## What it adds

- `type: rangeArea` as a series type, taking `[timestamp, [low, high]]`
- `statistics: {type: range}`, yielding each bucket's `[min, max]` pair
- `HistoryPoint` widened from `[number, number|null]` to `[number, StateValue]`,
  where `StateValue` may be a `[min, max]` pair

## What became unnecessary

Roughly half of #510 has been overtaken by `dev`. It shipped a `show.legend`
option; upstream has since built the same thing as `show.in_legend`. Upstream's
version is kept throughout, so only the range work remains. The `apexcharts`
bump is moot too — `dev` is on `^5.3.3`, past the `^3.36.0` it asked for.

## Fixes on top of the rebase

Five defects, all in the original and all reachable from a normal config:

- **`minMaxWithTimestamp` compared range points with `<`.** In JavaScript that
  falls back to comparing them as strings — `"9,10" < "10,30"` is `false` — so
  the wrong point won and a configured `yaxis` clipped the band flat at the
  top. It now compares the low edge for `min` and the high edge for `max`.
- **`_transformAndFill` looped `i < 3` over a 2-tuple**, appending a third
  element to every range point so they no longer matched their own type.
- **`_median` returned `a + b / 2` for ranges** — missing parentheses, roughly
  1.5× — and a bare number where the odd-length branch returns a pair. Now
  element-wise and shape-consistent.
- **`invert` produced `NaN`** at three sites — `_invertData`, the y-axis
  folding, and the `show.extremas` annotations — by negating the pair itself. A
  range now flips end for end: the negated high becomes the new low. The
  annotations were doubly wrong: they also received the `[low, high]` pair as
  their `y`, and labelled a maximum with the band's low edge.
- **Several places took only the low edge of a band**: the `min`/`max` getters,
  which feed the `color_threshold` stops that #510 enabled for `rangeArea`, and
  the `max` aggregator, which returned the maximum of the *undersides*.
  `Math.min` over a raw pair also turned a half-known band's `null` edge into a
  `0` and dragged the axis down with it.

## The tooltip

#510 notes "pop-up values not quite working properly". The cause is the forcing
itself:

```ts
if (def.chart.type === 'line' && def.series.some((s) => s.type === 'rangeArea'))
  def.chart.type = 'rangeArea';
```

Setting `chart.type = 'rangeArea'` switches ApexCharts to its range tooltip: one
series, no shared rows. In my testing a configured `tooltip.x.format` also came
out as `NaN.NaN.NaN` there, though I have not pinned that half down in the
ApexCharts source.

A mixed chart does not need the switch — ApexCharts draws a rangeArea series
from the per-series `type` alone, which I confirmed by overriding
`apex_config.chart.type: line` from the card config: the bands kept rendering and
the normal shared tooltip came back. So the forcing now applies only when *every*
series is a range, which is the case the range tooltip actually suits.

It does not fix everything: with a range and a line in one chart, ApexCharts
still renders every tooltip row as `low - high`, so the line reads `null - null`.
That is ApexCharts' own behaviour (`tooltip/Labels.js` branches on a chart-level
`isRangeData`), not something the card can reach — `apex_config.tooltip.custom`
is the way out. The README says so.

## Documentation

A `rangeArea` series section with an example, an entry in the `chart_type`
table, corrections to the `opacity` and `stroke_width` rows that this changes,
and the three things that bite in practice: missing points must be
`[null, null]` or ApexCharts throws on reading index `0`; the axis scaling issue
above; and the shared-tooltip limitation.

## In use

Daily minimum and maximum as a band with the mean through it, air and pool water
in one chart:

```yaml
type: custom:apexcharts-card
graph_span: 40d
series:
  - entity: sensor.outdoor_temperature
    name: Air range
    type: rangeArea
    opacity: 0.25
    stroke_width: 0
    statistics: { type: range, period: day }
  - entity: sensor.outdoor_temperature
    name: Air avg
    type: line
    statistics: { type: mean, period: day }
  - entity: sensor.pool_temperature
    name: Water range
    type: rangeArea
    opacity: 0.35
    stroke_width: 0
    statistics: { type: range, period: day }
  - entity: sensor.pool_temperature
    name: Water avg
    type: line
    statistics: { type: mean, period: day }
```
<img width="493" height="317" alt="rangearea-40-days" src="https://github.com/user-attachments/assets/d8feda6e-03e5-4ede-b9ee-80554d365931" />


The same treatment works month by month, with a grey band for the range the
three previous years spanned.

<img width="501" height="278" alt="rangearea-month-by-month" src="https://github.com/user-attachments/assets/97b1579f-fd0d-4e02-8e2b-76df8ad0e883" />


## Credit

The implementation is @Buddy-Matt's; this is their work rebased, with the
obsolete parts dropped, the defects above fixed and the README written. Happy to
split it differently, or to hand it back if they would rather carry it.
