### PR TITLE
feat(yaxis): tick_step - ticks every N units while the extremas follow the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ You can have as many y-axis as there are series defined in your configuration or
 | `decimals` | number | `1` | v1.10.0 | Number of decimals to show on this y-axis |
 | `apex_config` | object | | v1.9.0 | Any configuration from https://apexcharts.com/docs/options/yaxis/, except `min`, `max`, `show` and `opposite` |
 | `align_to` | number | | v1.10.0 | Aligns the yaxis extremas to the closest multiple of `align_to`. Only valid if `min` or `max` are not fixed values. |
+| `tick_step` | number | | v2.3.0 | Puts a tick (and a label) every `tick_step` units on this y-axis, e.g. `tick_step: 1` for `0, 1, 2, 3...`. The non-fixed extremas are aligned to a multiple of `tick_step` (unless `align_to` is set, which takes precedence) so every label lands on a round number, and the axis still follows the data, zoom and pan. Works with fixed `min`/`max` too. |
 
 #### Min/Max Format
 

--- a/src/apexcharts-card.ts
+++ b/src/apexcharts-card.ts
@@ -533,6 +533,7 @@ class ChartsCard extends LitElement {
       let yAxisDup: any = JSON.parse(JSON.stringify(config.yaxis![idx]));
       delete yAxisDup.apex_config;
       delete yAxisDup.decimals;
+      delete yAxisDup.tick_step;
       yAxisDup.decimalsInFloat =
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         config.yaxis![idx].decimals === undefined ? DEFAULT_FLOAT_PRECISION : config.yaxis![idx].decimals;
@@ -1242,15 +1243,16 @@ class ChartsCard extends LitElement {
             max = elt.max[1];
           }
         });
-        if (yaxis.align_to !== undefined) {
+        const alignTo = yaxis.align_to !== undefined ? yaxis.align_to : yaxis.tick_step;
+        if (alignTo !== undefined) {
           if (min !== null && yaxis.min_type !== minmax_type.FIXED) {
-            if (min % yaxis.align_to !== 0) {
-              min = min >= 0 ? min - (min % yaxis.align_to) : -(yaxis.align_to + (min % yaxis.align_to) - min);
+            if (min % alignTo !== 0) {
+              min = min >= 0 ? min - (min % alignTo) : -(alignTo + (min % alignTo) - min);
             }
           }
           if (max !== null && yaxis.max_type !== minmax_type.FIXED) {
-            if (max % yaxis.align_to !== 0) {
-              max = max >= 0 ? yaxis.align_to - (max % yaxis.align_to) + max : (max % yaxis.align_to) - max;
+            if (max % alignTo !== 0) {
+              max = max >= 0 ? alignTo - (max % alignTo) + max : (max % alignTo) - max;
             }
           }
         }
@@ -1277,6 +1279,20 @@ class ChartsCard extends LitElement {
           }
         });
       }
+    });
+    // tick_step: place a tick every `tick_step` units by deriving ApexCharts' tickAmount from the final
+    // extremas. Done here (not in _generateYAxisConfig) so it follows auto/soft/absolute extremas as they
+    // change with the data, zoom and pan, and still works when min/max are fixed.
+    this._yAxisConfig?.forEach((yaxis) => {
+      if (yaxis.tick_step === undefined || yaxis.tick_step <= 0) return;
+      yaxis.series_id?.forEach((id) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const axis = this._config!.apex_config!.yaxis![id];
+        if (typeof axis.min === 'number' && typeof axis.max === 'number' && axis.max > axis.min) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          axis.tickAmount = Math.max(1, Math.round((axis.max - axis.min) / yaxis.tick_step!));
+        }
+      });
     });
     return this._config?.apex_config?.yaxis;
   }

--- a/src/types-config-ti.ts
+++ b/src/types-config-ti.ts
@@ -164,6 +164,7 @@ export const ChartCardYAxisExternal = t.iface([], {
   "min": t.opt(t.union(t.lit('auto'), "number", "string")),
   "max": t.opt(t.union(t.lit('auto'), "number", "string")),
   "align_to": t.opt("number"),
+  "tick_step": t.opt("number"),
   "decimals": t.opt("number"),
   "apex_config": t.opt("any"),
 });

--- a/src/types-config.ts
+++ b/src/types-config.ts
@@ -166,6 +166,7 @@ export interface ChartCardYAxisExternal {
   min?: 'auto' | number | string;
   max?: 'auto' | number | string;
   align_to?: number;
+  tick_step?: number;
   decimals?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   apex_config?: any;


### PR DESCRIPTION
## What

Adds a `yaxis` option `tick_step`: put a tick (and a label) every `tick_step` units on that axis, e.g. `tick_step: 1` for `0, 1, 2, 3, ...`, while the axis extremas keep following the data, zoom and pan.

```yaml
yaxis:
  - id: kW
    min: 0
    max: auto
    decimals: 0
    tick_step: 1
```

## Why

Related to #1052 (integer / evenly-spaced ticks with a dynamic range). ApexCharts' own `stepSize` cannot be used for this from the card: the card always passes fixed numeric `min`/`max` to ApexCharts (that is how `auto`, `~N` and `|N|` work), and with both bounds fixed ApexCharts ignores `stepSize` and `forceNiceScale` and falls back to its default tick count. The only thing ApexCharts honours in that situation is `tickAmount`, which is static in the config today, so a range that follows the data cannot have round-number ticks.

## How

- After the auto/soft/absolute extremas are computed in `_computeYAxisAutoMinMax`, they are aligned to a multiple of `tick_step` (reusing the existing `align_to` logic; an explicit `align_to` still takes precedence), so every label lands on a round number.
- Then `tickAmount` is derived as `round((max - min) / tick_step)` and written into the per-series ApexCharts yaxis config alongside `min`/`max`. Because this runs where the extremas are recomputed, it follows the data, zoom and pan, and it also works when `min`/`max` are fixed.
- `tick_step` is stripped from the options passed to ApexCharts (like `decimals`), added to `ChartCardYAxisExternal` and the generated `types-config-ti.ts`, and documented in the README.

No behaviour change unless `tick_step` is set.

## Tested

On Home Assistant with the built bundle: a card with a peak of 11.1 kW and `min: 0, max: auto, tick_step: 1` renders ticks `0..12` exactly (verified by reading `w.globals.yAxisScale[0].result` from the chart object); without the option the same card renders `0, 2.02, 4.04, ...` from the default six intervals. Zooming into a low region re-scales to a smaller integer range. `npm run build` (types check, lint, rollup) passes in CI.